### PR TITLE
Move `bower` to devDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "bower": "^1.8.0",
     "ember-cli-babel": "^6.0.0-beta.9",
     "ember-data": "~2.14.10"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
+    "bower": "^1.8.0",
     "ember-ajax": "^2.4.1",
     "ember-cli": "^2.12.1",
     "ember-cli-dependency-checker": "^1.3.0",


### PR DESCRIPTION
It definitely should not be a `dependency`, but I wonder if we actually need it listed in deps or devDeps at all?  I don't spot any direct `bower` invocations, and `ember-try` already installs its own copy as needed...