### PR TITLE
Move ember-data to peerdep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   },
   "dependencies": {
     "bower": "^1.8.0",
-    "ember-cli-babel": "^6.0.0-beta.9",
+    "ember-cli-babel": "^6.0.0-beta.9"
+  },
+  "peerDependencies": {
     "ember-data": "~2.14.10"
   },
   "devDependencies": {
@@ -36,6 +38,7 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-data": "~2.14.10",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",


### PR DESCRIPTION
This partially addresses #18 but we should add a build-time assertion to make sure we're monkeypatching something we're good with, while working on making this use public API.