### PR TITLE
Adding unloadUrl and contains methods to the queryCache

### DIFF
--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -58,6 +58,10 @@ export function extendStore(Store) {
 
     unloadURL(cacheKey) {
       return this._queryCache.unloadURL(cacheKey);
+    },
+
+    containsURL(cacheKey) {
+      return this._queryCache.contains(cacheKey);
     }
   })
 }

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -55,6 +55,10 @@ export function extendStore(Store) {
     queryURL(url, options) {
       return this._queryCache.queryURL(url, options);
     },
+
+    unloadURL(cacheKey) {
+      return this._queryCache.unloadURL(cacheKey);
+    }
   })
 }
 

--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -73,10 +73,8 @@ export default class QueryCache {
     }
   }
 
-  contains(recordOrCacheKey) {
-    return recordOrCacheKey.constructor === String
-      ? !!this._queryCache[recordOrCacheKey]
-      : !!this._reverseQueryCache[recordOrCacheKey.id];
+  contains(cacheKey) {
+    return !!this._queryCache[cacheKey];
   }
 
   _buildUrl(url) {

--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -68,9 +68,7 @@ export default class QueryCache {
   }
 
   unloadURL(cacheKey) {
-    if (this.contains(cacheKey)) {
-      delete this._queryCache[cacheKey];
-    }
+    delete this._queryCache[cacheKey];
   }
 
   contains(cacheKey) {

--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -67,6 +67,18 @@ export default class QueryCache {
     delete this._reverseQueryCache[id];
   }
 
+  unloadURL(cacheKey) {
+    if (this.contains(cacheKey)) {
+      delete this._queryCache[cacheKey];
+    }
+  }
+
+  contains(recordOrCacheKey) {
+    return recordOrCacheKey.constructor === String
+      ? !!this._queryCache[recordOrCacheKey]
+      : !!this._reverseQueryCache[recordOrCacheKey.id];
+  }
+
   _buildUrl(url) {
     let parts = [];
 

--- a/tests/unit/initializers/m3-store-test.js
+++ b/tests/unit/initializers/m3-store-test.js
@@ -57,6 +57,23 @@ test('it adds `store.queryURL`', function(assert) {
   this.store.queryURL('/some-data', { params: { a: '1' }});
 });
 
+test('it adds `store.unloadURL`', function(assert) {
+  assert.expect(2);
+
+  const cacheKey = 'uwot';
+
+  assert.equal(typeof this.store.unloadURL, 'function', 'unloadURL added');
+  this.sinon.stub(this.store._queryCache, 'unloadURL').callsFake((...args) => {
+    assert.deepEqual(
+      [...args],
+      [cacheKey],
+      'arguments are passed down to queryCache'
+    );
+  });
+
+  this.store.unloadURL(cacheKey);
+});
+
 test('uses the -ember-m3 adapter for schema-recognized types', function(assert) {
   this.store.adapterFor('non-matching-type');
 

--- a/tests/unit/initializers/m3-store-test.js
+++ b/tests/unit/initializers/m3-store-test.js
@@ -74,6 +74,23 @@ test('it adds `store.unloadURL`', function(assert) {
   this.store.unloadURL(cacheKey);
 });
 
+test('it adds `store.containsURL`', function(assert) {
+  assert.expect(1);
+
+  const cacheKey = 'uwot';
+
+  assert.equal(typeof this.store.containsURL, 'function', 'containsURL added');
+  this.sinon.stub(this.store._queryCache, 'containsURL').callsFake((...args) => {
+    assert.deepEqual(
+      [...args],
+      [cacheKey],
+      'arguments are passed down to queryCache'
+    );
+  });
+
+  this.store.containsURL(cacheKey);
+});
+
 test('uses the -ember-m3 adapter for schema-recognized types', function(assert) {
   this.store.adapterFor('non-matching-type');
 

--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -562,26 +562,6 @@ test('contains by cacheKey correctly returns true when a query is cached', funct
   })
 });
 
-test('contains by record correctly returns true when a query is cached', function(assert) {
-  let firstPayload = {
-    data: {
-      id: 1,
-      type: 'my-type',
-      attributes: {},
-    }
-  };
-
-  this.adapterAjax.returns(resolve(firstPayload));
-
-  let cacheKey = 'uwot';
-  let options = { cacheKey };
-
-  return this.queryCache.queryURL('/uwot', options).then((model) => {
-
-    assert.ok(this.queryCache.contains(model));
-  })
-});
-
 test('models are removed from results when they are unloaded', function(assert) {
   let firstPayload = {
     data: [{

--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -521,6 +521,66 @@ test('multiple cache entries are invalidated if they both involve the same unloa
   });
 });
 
+test('the cache entry for a query is invalidated by cacheKey', function(assert) {
+  let firstPayload = {
+    data: {
+      id: 1,
+      type: 'my-type',
+      attributes: {},
+    }
+  };
+
+  this.adapterAjax.returns(resolve(firstPayload));
+
+  let cacheKey = 'uwot';
+  let options = { cacheKey };
+
+  return this.queryCache.queryURL('/uwot', options).then(() => {
+    this.queryCache.unloadURL(cacheKey);
+
+    assert.notOk(this.queryCache.contains(cacheKey));
+  })
+});
+
+test('contains by cacheKey correctly returns true when a query is cached', function(assert) {
+  let firstPayload = {
+    data: {
+      id: 1,
+      type: 'my-type',
+      attributes: {},
+    }
+  };
+
+  this.adapterAjax.returns(resolve(firstPayload));
+
+  let cacheKey = 'uwot';
+  let options = { cacheKey };
+
+  return this.queryCache.queryURL('/uwot', options).then(() => {
+
+    assert.ok(this.queryCache.contains(cacheKey));
+  })
+});
+
+test('contains by record correctly returns true when a query is cached', function(assert) {
+  let firstPayload = {
+    data: {
+      id: 1,
+      type: 'my-type',
+      attributes: {},
+    }
+  };
+
+  this.adapterAjax.returns(resolve(firstPayload));
+
+  let cacheKey = 'uwot';
+  let options = { cacheKey };
+
+  return this.queryCache.queryURL('/uwot', options).then((model) => {
+
+    assert.ok(this.queryCache.contains(model));
+  })
+});
 
 test('models are removed from results when they are unloaded', function(assert) {
   let firstPayload = {


### PR DESCRIPTION
@hjdivad @stefanpenner @rwjblue

This PR adds `unloadURL` and `contains` methods to the queryCache to enable unloading of cached queries.