### PR TITLE
Drop bower dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "bower": "^1.8.0",
     "ember-cli-babel": "^6.0.0-beta.9"
   },
   "peerDependencies": {


### PR DESCRIPTION
Supersede #17.

We don't actually use bower, it's just a holdover from the blueprint.