### PR TITLE
Migrate to merge strategy from overwrite strategy

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -333,7 +333,7 @@ export default class MegamorphicModel extends Ember.Object {
 
         let oldIsRecordArray = oldValue && oldValue.constructor === M3RecordArray;
         let oldWasModel = oldValue && oldValue.constructor === MegamorphicModel;
-        let newIsObject = newValue !== null && isObject(newValue);
+        let newIsObject = isObject(newValue);
 
         if (oldWasModel && newIsObject) {
           oldValue._didReceiveNestedProperties(internalModel._data[key], nestedKeys);

--- a/addon/model.js
+++ b/addon/model.js
@@ -4,7 +4,7 @@ import { dasherize } from '@ember/string';
 
 import SchemaManager from './schema-manager';
 import M3RecordArray from './record-array';
-import { OWNER_KEY, merge } from './util';
+import { OWNER_KEY, isObject, merge } from './util';
 
 const {
   changeProperties, get, set, propertyWillChange, propertyDidChange, computed, A
@@ -333,7 +333,7 @@ export default class MegamorphicModel extends Ember.Object {
 
         let oldIsRecordArray = oldValue && oldValue.constructor === M3RecordArray;
         let oldWasModel = oldValue && oldValue.constructor === MegamorphicModel;
-        let newIsObject = typeof newValue === 'object';
+        let newIsObject = newValue !== null && isObject(newValue);
 
         if (oldWasModel && newIsObject) {
           oldValue._didReceiveNestedProperties(internalModel._data[key], nestedKeys);

--- a/addon/util.js
+++ b/addon/util.js
@@ -26,7 +26,7 @@ export const OWNER_KEY = (function() {
 })();
 
 export function isObject(value) {
-  return typeof value === 'object' && value.constructor !== Date;
+  return value !== null && typeof value === 'object' && value.constructor !== Date;
 }
 
 export function merge(data, updates) {

--- a/addon/util.js
+++ b/addon/util.js
@@ -25,7 +25,7 @@ export const OWNER_KEY = (function() {
   }
 })();
 
-function isObject(value) {
+export function isObject(value) {
   return typeof value === 'object' && value.constructor !== Date;
 }
 
@@ -55,7 +55,8 @@ export function merge(data, updates) {
       changedKeys.push(key);
       continue;
     }
-    if (isObject(newValue)) {
+    // only recursively merge if both new and old values are objects
+    if (isObject(newValue) && isObject(data[key])) {
       // it's an object, check for recursion
       // TODO Optimize the checks here
       let nestedChanges = merge(data[key], newValue);

--- a/addon/util.js
+++ b/addon/util.js
@@ -31,6 +31,10 @@ function isObject(value) {
 
 export function merge(data, updates) {
   let changedKeys = [];
+  if (!updates) {
+    // no changes
+    return changedKeys;
+  }
   let updatedKeys = Object.keys(updates);
   for (let i = 0; i < updatedKeys.length; i++) {
     let key = updatedKeys[i];

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1391,6 +1391,7 @@ test('nested model updates model -> null (model reified)', function(assert) {
         type: 'com.example.bookstore.Book',
         attributes: {
           name: `Harry Potter and the Sorcerer's Stone`,
+          nextChapter: null,
         },
       },
     });
@@ -1475,6 +1476,7 @@ test('nested model updates model -> null (model inert)', function(assert) {
         type: 'com.example.bookstore.Book',
         attributes: {
           name: `Harry Potter and the Sorcerer's Stone`,
+          nextChapter: null,
         },
       },
     });
@@ -1660,6 +1662,7 @@ test('.save saves via the store', function(assert) {
       assert.deepEqual(model._internalModel._data, {
         name: 'The Winds of Winter',
         estimatedRating: '11/10',
+        estimatedPubDate: '2231?',
       }, 'data post save resolve');
     })
   );

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -928,10 +928,10 @@ test('attribute property changes are properly detected', function(assert) {
   ]);
 });
 
-test('omitted attributes are treated as deleted', function(assert) {
+test('omitted attributes do not trigger changes', function(assert) {
   let propChange = this.sinon.spy(MegamorphicModel.prototype, 'notifyPropertyChange');
 
-  let model = run(() => {
+  run(() => {
     return this.store().push({
       data: {
         id: 'isbn:9780439708180',
@@ -956,12 +956,48 @@ test('omitted attributes are treated as deleted', function(assert) {
     });
   });
 
-  assert.deepEqual(zip(propChange.thisValues.map(x => x+''), propChange.args), [
-    [model+'', ['name']],
-  ], 'omitted attributes are treated as deleted');
+  assert.deepEqual(
+    zip(propChange.thisValues.map(x => x+''), propChange.args),
+    [],
+    'omitted attributes do not trigger changes'
+  );
 });
 
-test('omitted attributes in nested models are treated as deleted', function(assert) {
+test('null attributes are detected as changed', function(assert) {
+  let propChange = this.sinon.spy(MegamorphicModel.prototype, 'notifyPropertyChange');
+
+  let model = run(() => {
+    return this.store().push({
+      data: {
+        id: 'isbn:9780439708180',
+        type: 'com.example.bookstore.Book',
+        attributes: {
+          name: `Harry Potter and the Sorcerer's Stone`,
+          author: 'JK Rowling',
+        },
+      },
+    });
+  });
+
+  run(() => {
+    return this.store().push({
+      data: {
+        id: 'isbn:9780439708180',
+        type: 'com.example.bookstore.Book',
+        attributes: {
+          name: null,
+          author: 'JK Rowling',
+        },
+      },
+    });
+  });
+
+  assert.deepEqual(zip(propChange.thisValues.map(x => x+''), propChange.args), [
+    [model+'', ['name']],
+  ], 'nulled attributes are treated as changed');
+});
+
+test('nulled attributes in nested models are detected as changed', function(assert) {
   let init = this.sinon.spy(MegamorphicModel.prototype, 'init');
   let propChange = this.sinon.spy(MegamorphicModel.prototype, 'notifyPropertyChange');
 
@@ -1007,11 +1043,13 @@ test('omitted attributes in nested models are treated as deleted', function(asse
           name: `Harry Potter and the Sorcerer's Stone`,
           nextChapter: {
             id: 'ch1',
-            number: 1,
+            name: null,
             nextChapter: {
               id: 'ch2',
+              name: null,
               number: 2,
-            }
+            },
+            number: 1,
           }
         },
       },
@@ -1023,14 +1061,75 @@ test('omitted attributes in nested models are treated as deleted', function(asse
     [doubleNested+'', ['name']],
     [doubleNested+'', ['number']],
     [nested+'', ['number']],
-  ], 'omitted attributes in nested models are deleted');
+  ], 'nulled attributes in nested models are detected as changed');
 
   assert.equal(get(nested, 'number'), 1);
-  assert.equal(get(nested, 'name'), undefined);
+  assert.equal(get(nested, 'name'), null);
   assert.equal(get(doubleNested, 'number'), 2);
-  assert.equal(get(doubleNested, 'name'), undefined);
+  assert.equal(get(doubleNested, 'name'), null);
 });
 
+test('omitted attributes in nested models are not detected as changed', function(assert) {
+  let propChange = this.sinon.spy(MegamorphicModel.prototype, 'notifyPropertyChange');
+
+  let model = run(() => {
+    return this.store().push({
+      data: {
+        id: 'isbn:9780439708180',
+        type: 'com.example.bookstore.Book',
+        attributes: {
+          name: `Harry Potter and the Sorcerer's Stone`,
+          nextChapter: {
+            id: 'ch1',
+            name: 'The Boy Who Lived',
+            number: 0,
+            nextChapter: {
+              id: 'ch2',
+              name: 'The Vanishing Glass',
+              number: 1,
+            }
+          }
+        },
+      },
+    });
+  });
+
+  assert.equal(propChange.callCount, 0, 'no property changes');
+
+  let nested = get(model, 'nextChapter');
+  let doubleNested = get(model, 'nextChapter.nextChapter');
+
+  run(() => {
+    return this.store().push({
+      data: {
+        id: 'isbn:9780439708180',
+        type: 'com.example.bookstore.Book',
+        attributes: {
+          name: `Harry Potter and the Sorcerer's Stone`,
+          nextChapter: {
+            id: 'ch1',
+            number: 0,
+            nextChapter: {
+              id: 'ch2',
+              number: 1,
+            }
+          }
+        },
+      },
+    });
+  });
+
+  assert.deepEqual(
+    zip(propChange.thisValues.map(x => x+''), propChange.args),
+    [],
+    'nulled attributes in nested models are detected as changed'
+  );
+
+  assert.equal(get(nested, 'number'), 0);
+  assert.equal(get(nested, 'name'), 'The Boy Who Lived');
+  assert.equal(get(doubleNested, 'number'), 1);
+  assert.equal(get(doubleNested, 'name'), 'The Vanishing Glass');
+});
 test('new attributes are treated as changed', function(assert) {
   let propChange = this.sinon.spy(MegamorphicModel.prototype, 'notifyPropertyChange');
 
@@ -1394,7 +1493,7 @@ test('nested model updates (model -> model) no changes', function(assert) {
   let init = this.sinon.spy(MegamorphicModel.prototype, 'init');
   let propChange = this.sinon.spy(MegamorphicModel.prototype, 'notifyPropertyChange');
 
-  let model = run(() => {
+  run(() => {
     return this.store().push({
       data: {
         id: 'isbn:9780439708180',
@@ -1429,9 +1528,11 @@ test('nested model updates (model -> model) no changes', function(assert) {
   });
 
   assert.equal(init.callCount, 1, 'no additional models created');
-  assert.deepEqual(zip(propChange.thisValues.map(x => x+''), propChange.args), [
-    [model+'', ['nextChapter']],
-  ], 'nested pojo -> pojo change even if hte values are deep equal');
+  assert.deepEqual(
+    zip(propChange.thisValues.map(x => x+''), propChange.args),
+    [],
+    'nested pojo -> pojo change is not triggered if the values are the same'
+  );
 });
 
 test('nested array attribute changes are properly detected', function(assert) {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1044,12 +1044,12 @@ test('nulled attributes in nested models are detected as changed', function(asse
           nextChapter: {
             id: 'ch1',
             name: null,
+            number: 1,
             nextChapter: {
               id: 'ch2',
               name: null,
               number: 2,
             },
-            number: 1,
           }
         },
       },
@@ -1058,9 +1058,9 @@ test('nulled attributes in nested models are detected as changed', function(asse
 
   assert.deepEqual(zip(propChange.thisValues.map(x => x+''), propChange.args), [
     [nested+'', ['name']],
+    [nested+'', ['number']],
     [doubleNested+'', ['name']],
     [doubleNested+'', ['number']],
-    [nested+'', ['number']],
   ], 'nulled attributes in nested models are detected as changed');
 
   assert.equal(get(nested, 'number'), 1);

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1,4 +1,4 @@
-import { module, test, todo } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupTest }  from 'ember-qunit';
 import Ember from 'ember';
 import MegamorphicModel from 'ember-m3/model';
@@ -147,7 +147,7 @@ module('unit/projection', function(hooks) {
     });
   });
 
-  todo(`store.peekRecord() will only return a projection or base-record if it has been fetched`, function(assert) {
+  skip(`store.peekRecord() will only return a projection or base-record if it has been fetched`, function(assert) {
     assert.expect(4);
 
     const UNFETCHED_PROJECTION_ID = 'isbn:9780439708180';
@@ -207,7 +207,7 @@ module('unit/projection', function(hooks) {
     assert.equal(record, undefined, 'The unfetched base-record with a fetched projection is unfound by peekRecord()');
   });
 
-  todo(`store.findRecord() will only fetch a projection or base-model if it has not been fetched previously`, function(assert) {
+  skip(`store.findRecord() will only fetch a projection or base-model if it has not been fetched previously`, function(assert) {
     assert.expect(12);
 
     const UNFETCHED_PROJECTION_ID = 'isbn:9780439708180';
@@ -1448,17 +1448,17 @@ module('unit/projection', function(hooks) {
     });
   });
 
-  todo(`Updates to a projection's non-whitelisted attributes do not cause a projection to be dirtied`, function() {});
+  skip(`Updates to a projection's non-whitelisted attributes do not cause a projection to be dirtied`, function() {});
 
-  todo(`Unloading a projection does not unload the base-record`, function() {});
-  todo(`Unloading the base-record does not unload the projection`, function() {});
-  todo(`Destroying the base-record does not unload/destroy the projection`, function() {});
-  todo(`Destroying the projection does not unload/destroy the base-record`, function() {});
+  skip(`Unloading a projection does not unload the base-record`, function() {});
+  skip(`Unloading the base-record does not unload the projection`, function() {});
+  skip(`Destroying the base-record does not unload/destroy the projection`, function() {});
+  skip(`Destroying the projection does not unload/destroy the base-record`, function() {});
 
   // TL;DR we can only proxy something that has an ID
-  todo(`Saving a newly created projection doesn't mess up the state of the base record`, function() {});
+  skip(`Saving a newly created projection doesn't mess up the state of the base record`, function() {});
 
-  todo(`Creating a projection with an unloaded schema`, function() {});
-  todo(`Finding a projection with an unloaded schema`, function() {});
-  todo(`fetched schemas must be complete (projected types must also be included)`, function() {});
+  skip(`Creating a projection with an unloaded schema`, function() {});
+  skip(`Finding a projection with an unloaded schema`, function() {});
+  skip(`fetched schemas must be complete (projected types must also be included)`, function() {});
 });

--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -683,7 +683,7 @@ test('update uses the original http method and query params', function(assert) {
   };
 
   this.adapterAjax.returns(resolve(payload));
-  this.queryCache.queryURL('/ohai', { method: 'POST', params: { q: 'v' }}).
+  return this.queryCache.queryURL('/ohai', { method: 'POST', params: { q: 'v' }}).
     then(models => models.update()).
     then(() => {
       assert.deepEqual(

--- a/tests/unit/util-test.js
+++ b/tests/unit/util-test.js
@@ -94,4 +94,10 @@ module('unit/util', function() {
     }, updates));
     assert.deepEqual(changedKeys, expectedChangedKeys);
   });
+
+  test('returns no changes for undefined updates', function(assert) {
+    let changedKeys = merge({}, undefined);
+
+    assert.deepEqual(changedKeys, []);
+  });
 });

--- a/tests/unit/util-test.js
+++ b/tests/unit/util-test.js
@@ -100,4 +100,35 @@ module('unit/util', function() {
 
     assert.deepEqual(changedKeys, []);
   });
+
+  test('handles type changes in the properties', function(assert) {
+    let data = {
+      objectProp: {
+        stringProp: 'stringValue'
+      },
+      stringProp: 'stringValue',
+      numberProp: 1,
+    };
+
+    let updates = {
+      objectProp: 'stringValue',
+      stringProp: {
+        stringProp: 'stringValue'
+      },
+      // checks whether Date is treated as object
+      numberProp: new Date()
+    };
+
+    let expectedChangedKeys = [
+      'objectProp',
+      'stringProp',
+      'numberProp'
+    ];
+
+    let changedKeys = merge(data, updates);
+
+    // we don't have omitted keys, so data must look like updates
+    assert.deepEqual(data, updates);
+    assert.deepEqual(changedKeys, expectedChangedKeys);
+  });
 });


### PR DESCRIPTION
The migration is not ready yet, there are still some tests failing mainly for cases, which change the type of properties (primitive -> model, model -> primitive) etc.

But I've adjusted the existing tests for detecting deleted properties and split them in tests for validating omitted properties do not trigger changes and nulled properties trigger changes. These are worth reviewing.