### PR TITLE
Fix the `isDirty` property

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -478,11 +478,11 @@ MegamorphicModel.prototype.adapterError = null;
 MegamorphicModel.relationshipsByName = new Ember.Map();
 
 // STATE PROPS
-MegamorphicModel.prototype.isEmpty = retrieveFromCurrentState
-MegamorphicModel.prototype.isLoading = retrieveFromCurrentState
-MegamorphicModel.prototype.isLoaded = retrieveFromCurrentState
-MegamorphicModel.prototype.isDirty = retrieveFromCurrentState
-MegamorphicModel.prototype.isSaving = retrieveFromCurrentState
-MegamorphicModel.prototype.isDeleted = retrieveFromCurrentState
-MegamorphicModel.prototype.isNew = retrieveFromCurrentState
+MegamorphicModel.prototype.isEmpty = retrieveFromCurrentState;
+MegamorphicModel.prototype.isLoading = retrieveFromCurrentState;
+MegamorphicModel.prototype.isLoaded = retrieveFromCurrentState;
+MegamorphicModel.prototype.isSaving = retrieveFromCurrentState;
+MegamorphicModel.prototype.isDeleted = retrieveFromCurrentState;
+MegamorphicModel.prototype.isNew = retrieveFromCurrentState;
 MegamorphicModel.prototype.isValid = retrieveFromCurrentState;
+MegamorphicModel.prototype.dirtyType = retrieveFromCurrentState;

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1546,10 +1546,10 @@ module('unit/model', function(hooks) {
       });
     });
 
-    assert.equal(model.get('isDirty'), false, 'initially model clean');
+    assert.equal(model.get('dirtyType'), null, 'initially model clean');
     assert.equal(model.get('isSaving'), false, 'initially model not saving');
     model.set('estimatedPubDate', '2231?');
-    assert.equal(model.get('isDirty'), false, 'no dirty tracking support');
+    assert.equal(model.get('dirtyType'), null, 'no dirty tracking support');
 
     return run(() =>
       model.save().then(() => {


### PR DESCRIPTION
The `isDirty` property doesn't actually exist in the `DS.Model`. The closest there is `dirtyType`. We should either fix it or drop it completely.