### PR TITLE
[Projection Support] Addressing some feedback from PR #38

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -226,18 +226,18 @@ export default class MegamorphicModel extends Ember.Object {
     this._store = properties.store;
     this.id = this._internalModel.id;
     this._internalModel = properties._internalModel;
-    this._projections = null;
 
     this._schema = SchemaManager;
 
     let baseModelName = this._schema.computeBaseModelName(this._modelName);
     this._baseModel = baseModelName ? this.initBaseModel(baseModelName) : null;
+    this._projections = null;
+    this._path = this._path || [];
 
     this._cache = Object.create(null);
 
     this._topModel = this._topModel || this;
     this._parentModel = this._parentModel || null;
-    this._path = this._path || [];
     this._init = true;
 
     this._flushInitProperties();
@@ -290,7 +290,15 @@ export default class MegamorphicModel extends Ember.Object {
   }
 
   get _modelName() {
-    return this._internalModel.modelName;
+    return this.__internalModel.modelName;
+  }
+
+  get _internalModel() {
+    return this.baseModel ? this.baseModel._internalModel : this.__internalModel;
+  }
+
+  set _internalModel(internalModel) {
+    this.__internalModel = internalModel;
   }
 
   __defineNonEnumerable(property) {
@@ -565,7 +573,6 @@ export default class MegamorphicModel extends Ember.Object {
 }
 
 MegamorphicModel.prototype.store = null;
-MegamorphicModel.prototype._internalModel = null;
 MegamorphicModel.prototype._parentModel = null;
 MegamorphicModel.prototype._topModel = null;
 MegamorphicModel.prototype._path = null;

--- a/addon/model.js
+++ b/addon/model.js
@@ -4,7 +4,7 @@ import { dasherize } from '@ember/string';
 
 import SchemaManager from './schema-manager';
 import M3RecordArray from './record-array';
-import { OWNER_KEY, isObject, merge } from './util';
+import { OWNER_KEY, isEmbeddedObject, merge } from './util';
 
 const {
   assert, changeProperties, get, set, propertyDidChange, computed, A
@@ -367,7 +367,7 @@ export default class MegamorphicModel extends Ember.Object {
 
         let oldIsRecordArray = oldValue && oldValue instanceof M3RecordArray;
         let oldWasModel = oldValue && oldValue instanceof EmbeddedMegamorphicModel;
-        let newIsObject = isObject(newValue);
+        let newIsObject = isEmbeddedObject(newValue);
 
         if (oldWasModel && newIsObject) {
           let nestedKeys = changedKeys[key];

--- a/addon/util.js
+++ b/addon/util.js
@@ -26,7 +26,7 @@ export const OWNER_KEY = (function() {
 })();
 
 export function isObject(value) {
-  return value !== null && typeof value === 'object' && value.constructor !== Date;
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
 /**
@@ -72,17 +72,6 @@ export function merge(data, updates) {
     if (isEqual(data[key], newValue)) {
       // values are equal, nothing to do
       // note, updates to objects should always result in new object or there will be nothing to update
-      continue;
-    }
-    if (data[key] == null || newValue == null) {
-      // reseting a value to null or assigning a value for first time can be handled for all cases
-      data[key] = newValue;
-      changedKeys[key] = true;
-      continue;
-    }
-    if (Array.isArray(newValue)) {
-      data[key] = newValue;
-      changedKeys[key] = true;
       continue;
     }
     // only recursively merge if both new and old values are objects

--- a/addon/util.js
+++ b/addon/util.js
@@ -25,7 +25,7 @@ export const OWNER_KEY = (function() {
   }
 })();
 
-export function isObject(value) {
+export function isEmbeddedObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
@@ -75,7 +75,7 @@ export function merge(data, updates) {
       continue;
     }
     // only recursively merge if both new and old values are objects
-    if (isObject(newValue) && isObject(data[key])) {
+    if (isEmbeddedObject(newValue) && isEmbeddedObject(data[key])) {
       // it's an object, check for recursion
       // TODO Optimize the checks here
       let nestedChanges = merge(data[key], newValue);

--- a/tests/unit/util-test.js
+++ b/tests/unit/util-test.js
@@ -1,17 +1,15 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import { merge } from 'ember-m3/util';
+import { merge, isObject } from 'ember-m3/util';
 
 const { assign } = Ember;
 
 module('unit/util', function() {
   test('merge should handle flat objects', function(assert) {
-    let now = new Date();
     let data = {
       sameProp: 'sameValue',
       stringProp: 'stringValue',
       numberProp: 1,
-      dateProp: now,
       arrayProp: [1, 2, 3],
       nullProp: null,
       nonNullProp: 'stringValue',
@@ -22,7 +20,6 @@ module('unit/util', function() {
       sameProp: 'sameValue',
       stringProp: 'newStringValue',
       numberProp: 2,
-      dateProp: new Date(now + 1000),
       arrayProp: [4, 5, 6],
       nullProp: 'nonNullValue',
       nonNullProp: null
@@ -31,7 +28,6 @@ module('unit/util', function() {
     let expectedChangedKeys = {
       stringProp: true,
       numberProp: true,
-      dateProp: true,
       arrayProp: true,
       nullProp: true,
       nonNullProp: true,
@@ -133,5 +129,15 @@ module('unit/util', function() {
     // we don't have omitted keys, so data must look like updates
     assert.deepEqual(data, updates);
     assert.deepEqual(changedKeys, expectedChangedKeys);
+  });
+
+  test('isObject should correctly return true/false', function(assert) {
+    assert.equal(isObject(undefined), false);
+    assert.equal(isObject(null), false);
+    assert.equal(isObject([]), false);
+    assert.equal(isObject(1), false);
+    assert.equal(isObject(''), false);
+    assert.equal(isObject({}), true);
+    assert.equal(isObject(new Date()), true);
   });
 });

--- a/tests/unit/util-test.js
+++ b/tests/unit/util-test.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { module, test } from 'qunit';
-import { merge, isObject } from 'ember-m3/util';
+import { merge, isEmbeddedObject } from 'ember-m3/util';
 
 const { assign } = Ember;
 
@@ -131,13 +131,13 @@ module('unit/util', function() {
     assert.deepEqual(changedKeys, expectedChangedKeys);
   });
 
-  test('isObject should correctly return true/false', function(assert) {
-    assert.equal(isObject(undefined), false);
-    assert.equal(isObject(null), false);
-    assert.equal(isObject([]), false);
-    assert.equal(isObject(1), false);
-    assert.equal(isObject(''), false);
-    assert.equal(isObject({}), true);
-    assert.equal(isObject(new Date()), true);
+  test('isEmbeddedObject should correctly return true/false', function(assert) {
+    assert.equal(isEmbeddedObject(undefined), false);
+    assert.equal(isEmbeddedObject(null), false);
+    assert.equal(isEmbeddedObject([]), false);
+    assert.equal(isEmbeddedObject(1), false);
+    assert.equal(isEmbeddedObject(''), false);
+    assert.equal(isEmbeddedObject({}), true);
+    assert.equal(isEmbeddedObject(new Date()), true);
   });
 });


### PR DESCRIPTION
This addresses some of the feedback from PR #38 

- Grouped the projection related properties in the `init` function.
- Converted `_internalModel` to be a getter, which always delegates to the `baseModel`.
- Cleaned up the `merge` function and removed the check for `Date` in the `isObject` function.
- Removed the `modelIsProjection` function from the `SchemaManager`
