### PR TITLE
Cleanup tests and SchemaManager based on code-review

### DIFF
--- a/addon/schema-manager.js
+++ b/addon/schema-manager.js
@@ -3,14 +3,6 @@ export class SchemaManager {
     this.schema = null;
   }
 
-  modelIsProjection(modelName) {
-    if (!this.schema || typeof this.schema.modelIsProjection !== 'function') {
-      return false;
-    }
-
-    return this.schema.modelIsProjection(modelName);
-  }
-
   computeBaseModelName(projectionModelName) {
     if (!this.schema || typeof this.schema.computeBaseModelName !== 'function') {
       return;
@@ -59,10 +51,6 @@ export class SchemaManager {
     let transform = transforms && transforms[attrName];
 
     return transform ? transform(value) : value;
-  }
-
-  registerAsyncSchemas(schemas) {
-    this.schema.registerAsyncSchemas(schemas);
   }
 
   registerSchema(schema) {

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -92,27 +92,7 @@ module('unit/projection', function(hooks) {
       },
 
       models: {
-        [NORM_BOOK_CLASS_PATH]: {
-          aliases: {
-            name: 'title',
-            cost: 'price',
-            pub: 'publisher',
-            releaseDate: 'pubDate',
-            pb: 'paperback',
-            hb: 'hardback',
-          },
-          defaults: {
-            publisher: 'Penguin Classics',
-            hardback: true,
-            paperback: true,
-            publishedIn: 'US',
-          },
-          transforms: {
-            pubDate(value) {
-              return new Date(Date.parse(value));
-            },
-          },
-        },
+        [NORM_BOOK_CLASS_PATH]: {},
         [NORM_BOOK_EXCERPT_PROJECTION_CLASS_PATH]: {
           projectedType: NORM_BOOK_CLASS_PATH,
           attributes: ['title', 'author', 'year', 'publisher'],

--- a/tests/unit/schema-manager-test.js
+++ b/tests/unit/schema-manager-test.js
@@ -116,24 +116,4 @@ module('unit/schema-manager', function() {
   test('.transformValue does not error when no schema is registered', function(assert) {
     assert.equal(SchemaManager.transformValue('com.example.moves.Movie', 'name', 'jeff'), 'jeff');
   });
-
-  test('can specify what projections the schema handles', function(assert) {
-    SchemaManager.registerSchema({
-      modelIsProjection(modelName) {
-        return /^com\.example\.bookstore\.projection\./i.test(modelName);
-      },
-      includesModel(modelName) {
-        return /^com\.example\.bookstore\./i.test(modelName);
-      },
-      models: {
-        'com.example.bookstore.Book': {},
-        'com.example.bookstore.projection.BookExcerpt': {},
-      }
-    });
-
-    assert.equal(SchemaManager.includesModel('com.example.bookstore.Book'), true, 'Book is a schema');
-    assert.equal(SchemaManager.includesModel('com.example.petstore.Details'), false, 'Details is not a schema');
-    assert.equal(SchemaManager.modelIsProjection('com.example.bookstore.projection.BookExcerpt'), true, 'BookExcerpt is a projection');
-    assert.equal(SchemaManager.modelIsProjection('com.example.petstore.projection.DetailsOverview'), false, 'DetailsOverview is not a projection');
-  });
 });


### PR DESCRIPTION
Also required altering our `store.preloadData` implementation as it surfaced an issue with property-notification for already populated models. It is now more similar to `store._load` but keeps the record in the EmptyState and skips notifying the record-array-manager if it truly is a "preload" and not an update. cc @igorT 