### PR TITLE
[Projection Support] Unload tests

### DIFF
--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1594,6 +1594,8 @@ module('unit/projection', function(hooks) {
       assert.equal(get(projectedPreview, '_internalModel.isDestroyed'), false);
       assert.equal(get(projectedPreview, 'title'), BOOK_TITLE);
     });
+
+    skip('Projection list is cleaned up after all projections have been unloaded', function() {});
   });
 
   // TL;DR we can only proxy something that has an ID


### PR DESCRIPTION
Here are is an expansion of the two unload tests we had. Hopefully I stayed `true` to the spirit of the test structure.

Only real question is how much we want to test that unloading a related record didn't destroy internal structures, which a live record might need.

Depending on our implementation we may need a test to confirm that the underlying structure has been cleaned up of references once the final projection has been unloaded, but without an actual implementation, I don't think it is possible to write a test for it.