### PR TITLE
[Projection Support] Write Tests

### DIFF
--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1808,12 +1808,6 @@ module('unit/projection', function(hooks) {
       assert.equal(get(baseModel, '_internalModel.currentState.isDirty'), true, 'The base model should still be dirty');
     });
   });
-<<<<<<< 093cbbb25bdfb2a57ae06a44839ab907660e14b0
-=======
-
-  // TL;DR we can only proxy something that has an ID
-  skip(`Saving a newly created projection doesn't mess up the state of the base record`, function() {});
->>>>>>> create and update tests
 
   skip(`eachAttribute returns only white-listed properties`, function() {});
   skip(`Creating a projection with an unloaded schema`, function() {});

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1598,7 +1598,7 @@ module('unit/projection', function(hooks) {
     skip('Projection list is cleaned up after all projections have been unloaded', function() {});
   });
 
-  module('creating/updating projections', function() {
+  module('creating/updating projections', function(hooks) {
     const BOOK_ID = 'isbn:123';
     const BOOK_TITLE_1 = 'Alice in Wonderland';
     const BOOK_TITLE_2 = 'Alice Through the Looking Glass';
@@ -1796,6 +1796,12 @@ module('unit/projection', function(hooks) {
       assert.equal(get(baseModel, '_internalModel.currentState.isDirty'), true, 'The base model should still be dirty');
     });
   });
+<<<<<<< 093cbbb25bdfb2a57ae06a44839ab907660e14b0
+=======
+
+  // TL;DR we can only proxy something that has an ID
+  skip(`Saving a newly created projection doesn't mess up the state of the base record`, function() {});
+>>>>>>> create and update tests
 
   skip(`eachAttribute returns only white-listed properties`, function() {});
   skip(`Creating a projection with an unloaded schema`, function() {});

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1598,14 +1598,14 @@ module('unit/projection', function(hooks) {
     skip('Projection list is cleaned up after all projections have been unloaded', function() {});
   });
 
-  module('creating/updating projections', function(hooks) {
+  module('creating/updating projections', function(/*hooks*/) {
     const BOOK_ID = 'isbn:123';
     const BOOK_TITLE_1 = 'Alice in Wonderland';
     const BOOK_TITLE_2 = 'Alice Through the Looking Glass';
     const BOOK_CHAPTER_1 = 'Down the Rabbit-Hole';
     const BOOK_CHAPTER_2 = 'Looking-Glass House';
 
-    skip('created projections of the same base type are independent', function(assert) {
+    skip('independently created projections of the same base-type but no ID do not share their data', function(assert) {
       let projectedPreview = this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
         title: BOOK_TITLE_1
       });
@@ -1617,7 +1617,19 @@ module('unit/projection', function(hooks) {
       assert.equal(get(projectedExcerpt, 'title'), BOOK_TITLE_2, 'Expected title of excerpt projection to be correct');
     });
 
-    skip('created projections of the same base type and ID are linked', function(assert) {
+    skip('independently created projections of the same projection-type but no ID do not share their data', function(assert) {
+      let projectedPreview1 = this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
+        title: BOOK_TITLE_1
+      });
+      let projectedPreview2 = this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
+        title: BOOK_TITLE_2
+      });
+
+      assert.equal(get(projectedPreview1, 'title'), BOOK_TITLE_1, 'Expected title of preview projection to be correct');
+      assert.equal(get(projectedPreview2, 'title'), BOOK_TITLE_2, 'Expected title of the second preview projection to be correct');
+    });
+
+    skip('independently created projections of the same base-type and ID share their data', function(assert) {
       let projectedPreview = this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
         id: BOOK_ID,
         title: BOOK_TITLE_1
@@ -1636,7 +1648,7 @@ module('unit/projection', function(hooks) {
       assert.equal(get(projectedExcerpt, 'title'), BOOK_TITLE_1, 'Expected title of excerpt projection to be updated');
     });
 
-    skip('create same projection type and ID is disallowed', function(assert) {
+    skip('independently creating projections of the same projection-type and ID is not allowed', function(assert) {
       this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
         id: BOOK_ID
       });


### PR DESCRIPTION
A starting point for the write cases discussion. I think writing projection is not as straight-forward, I expect to have some healthy discussion here.

The current thought process was the following:
- projections without IDs are not linked in any way, e.g. you can create as many as you want and modify as much as you want
- created projections with IDs are immediately linked, e.g. they represent the same underlying entity, even though this entity doesn't exist on the server
- saving a new projection record can create an entity on the server and the projection will be correctly setup to be updated by future fetches
- changing a projection dirties all associated entities (if they contain the attribute; note - the test needs to be enhanced to cover non-whitelisted properties)
- saving a projection un-dirties only the saved projection and any projection which have all of its properties saved. projections, which have properties, which have not been sent to the server continue to be dirty

I will continue enhancing these, but I also wanted to get some initial feedback about how we should be handling the write cases. One major obstacle in implementing the above rules is the fact M3 doesn't really support dirtying.

Also, we can reduce the scope for now and support something much simpler for the write cases, but not quite sure what would be a good compromise.