### PR TITLE
[FEAT] disallow late ID setting

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -214,7 +214,6 @@ export default class MegamorphicModel extends Ember.Object {
     super.init(...arguments);
     this._store = properties.store;
     this._internalModel = properties._internalModel;
-    this.id = this._internalModel.id;
     this._cache = Object.create(null);
     this._schema = SchemaManager;
 
@@ -410,6 +409,19 @@ export default class MegamorphicModel extends Ember.Object {
     return (this._cache[key] = resolveValue(key, value, this._modelName, this._store, this._schema, this));
   }
 
+  get id() {
+    return this._internalModel.id;
+  }
+
+  set id(value) {
+    if (!this._init) {
+      this._internalModel.id = value;
+      return;
+    }
+
+    throw new Error(`You tried to set 'id' to '${value}' for '${this._modelName}' but records can only set their ID by providing it to store.createRecord()`);
+  }
+
   // TODO: drop change events for unretrieved properties
   setUnknownProperty(key, value) {
     if (key === OWNER_KEY) {
@@ -472,7 +484,6 @@ MegamorphicModel.prototype.store = null;
 MegamorphicModel.prototype._internalModel = null;
 MegamorphicModel.prototype._parentModel = null;
 MegamorphicModel.prototype._topModel = null;
-MegamorphicModel.prototype.id = null;
 MegamorphicModel.prototype.currentState = null;
 MegamorphicModel.prototype.isError = null;
 MegamorphicModel.prototype.adapterError = null;

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,8 +1,11 @@
+import Ember from 'ember';
 import resolver from './helpers/resolver';
 import {
   setResolver
 } from 'ember-qunit';
 import { start } from 'ember-cli-qunit';
+
+Ember.Test.adapter.exception = (reason) => { throw reason; };
 
 setResolver(resolver);
 start();

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -5,7 +5,7 @@ import {
 } from 'ember-qunit';
 import { start } from 'ember-cli-qunit';
 
-Ember.Test.adapter.exception = (reason) => { throw reason; };
+Ember.Test.Adapter.exception = (reason) => { throw reason; };
 
 setResolver(resolver);
 start();

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -5,7 +5,7 @@ import {
 } from 'ember-qunit';
 import { start } from 'ember-cli-qunit';
 
-Ember.Test.Adapter.exception = (reason) => { throw reason; };
-
 setResolver(resolver);
 start();
+
+Ember.Test.adapter.exception = (reason) => { throw reason; };

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupTest }  from 'ember-qunit';
 import sinon from 'sinon';
 
@@ -678,6 +678,26 @@ module('unit/model', function(hooks) {
     );
 
     assert.equal(get(model, 'publisher'), 'Harper Collins, of course', 'specified value transformed');
+  });
+
+  test('early set of an ID to a newly created records is allowed', function(assert) {
+    let model = run(() =>
+      this.store.createRecord('com.example.bookstore.Book', {
+        id: 'my-crazy-id',
+      })
+    );
+
+    assert.equal(get(model, 'id'), 'my-crazy-id', 'init id property set');
+  });
+
+  skip('late set of an ID to a newly created records is not allowed', function(assert) {
+    let model = run(() =>
+      this.store.createRecord('com.example.bookstore.Book', {
+        name: 'Marlborough: His Life and Times',
+      })
+    );
+
+    assert.throws(() => { run(() => { set(model, 'id', 'my-crazy-id') }) }, /You tried to set 'id' to 'my-crazy-id' for 'com.example.bookstore.book' but newly created records can only set their ID by providing it to `createRecord\(\)`/, 'error to set ID late');
   });
 
   // This is unspecified behaviour; unclear if we can do anything sane here

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -698,7 +698,7 @@ module('unit/model', function(hooks) {
     );
 
     assert.throws(() => {
-      run(() => { set(model, 'id', 'my-crazy-id') });
+      set(model, 'id', 'my-crazy-id');
     }, /You tried to set 'id' to 'my-crazy-id' for 'com.example.bookstore.book' but records can only set their ID by providing it to store.createRecord\(\)/, 'error to set ID late');
   });
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1,4 +1,4 @@
-import { module, test, skip } from 'qunit';
+import { module, test } from 'qunit';
 import { setupTest }  from 'ember-qunit';
 import sinon from 'sinon';
 
@@ -690,14 +690,16 @@ module('unit/model', function(hooks) {
     assert.equal(get(model, 'id'), 'my-crazy-id', 'init id property set');
   });
 
-  skip('late set of an ID to a newly created records is not allowed', function(assert) {
+  test('late set of an ID to a newly created records is not allowed', function(assert) {
     let model = run(() =>
       this.store.createRecord('com.example.bookstore.Book', {
         name: 'Marlborough: His Life and Times',
       })
     );
 
-    assert.throws(() => { run(() => { set(model, 'id', 'my-crazy-id') }) }, /You tried to set 'id' to 'my-crazy-id' for 'com.example.bookstore.book' but newly created records can only set their ID by providing it to `createRecord\(\)`/, 'error to set ID late');
+    assert.throws(() => {
+      run(() => { set(model, 'id', 'my-crazy-id') });
+    }, /You tried to set 'id' to 'my-crazy-id' for 'com.example.bookstore.book' but records can only set their ID by providing it to store.createRecord\(\)/, 'error to set ID late');
   });
 
   // This is unspecified behaviour; unclear if we can do anything sane here


### PR DESCRIPTION
As discussed OOB with @hjdivad, this PR asserts that you cannot `model.set('id', '1')`.

For client-side creation with ID, ID must be passed in via `store.createRecord('foo', { id: '1' });`

cc @dnachev 