### PR TITLE
[Projection Support] Merge strategy refactor on top of model data

### DIFF
--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -1,8 +1,7 @@
 import { assign, merge } from '@ember/polyfills';
-import { isEqual } from '@ember/utils';
 import { copy } from '@ember/object/internals';
 import { get } from '@ember/object';
-import { setDiff, merge as mergeData } from './util';
+import { merge as mergeData } from './util';
 
 const emberAssign = assign || merge;
 
@@ -263,113 +262,4 @@ export default class M3ModelData {
 
   // TODO IGOR AND DAVID REFACTOR THIS
   didCreateLocally() {}
-
-  /*
-      Ember Data has 3 buckets for storing the value of an attribute on an internalModel.
-  
-      `_data` holds all of the attributes that have been acknowledged by
-      a backend via the adapter. When rollbackAttributes is called on a model all
-      attributes will revert to the record's state in `_data`.
-  
-      `_attributes` holds any change the user has made to an attribute
-      that has not been acknowledged by the adapter. Any values in
-      `_attributes` are have priority over values in `_data`.
-  
-      `_inFlightAttributes`. When a record is being synced with the
-      backend the values in `_attributes` are copied to
-      `_inFlightAttributes`. This way if the backend acknowledges the
-      save but does not return the new state Ember Data can copy the
-      values from `_inFlightAttributes` to `_data`. Without having to
-      worry about changes made to `_attributes` while the save was
-      happenign.
-  
-  
-      Changed keys builds a list of all of the values that may have been
-      changed by the backend after a successful save.
-  
-      It does this by iterating over each key, value pair in the payload
-      returned from the server after a save. If the `key` is found in
-      `_attributes` then the user has a local changed to the attribute
-      that has not been synced with the server and the key is not
-      included in the list of changed keys.
-  
-  
-  
-      If the value, for a key differs from the value in what Ember Data
-      believes to be the truth about the backend state (A merger of the
-      `_data` and `_inFlightAttributes` objects where
-      `_inFlightAttributes` has priority) then that means the backend
-      has updated the value and the key is added to the list of changed
-      keys.
-  
-      @method _changedKeys
-      @private
-    */
-  _changedKeys(updates) {
-    //        let changedKeys = [];
-
-    // TODO IGOR DAVID MAYBE REMOVE
-    if (!updates) {
-      return [];
-    }
-
-    return calculateChangedKeys(this._data, updates);
-
-    /*
-      if (updates) {
-        let original, i, value, key;
-        let keys = Object.keys(updates);
-        let length = keys.length;
-        let hasAttrs = this.hasChangedAttributes();
-        let attrs;
-        if (hasAttrs) {
-          attrs= this._attributes;
-        }
-  
-        original = emberAssign(Object.create(null), this._data);
-        original = emberAssign(original, this._inFlightAttributes);
-  
-        for (i = 0; i < length; i++) {
-          key = keys[i];
-          value = updates[key];
-  
-          // A value in _attributes means the user has a local change to
-          // this attributes. We never override this value when merging
-          // updates from the backend so we should not sent a change
-          // notification if the server value differs from the original.
-          if (hasAttrs === true && attrs[key] !== undefined) {
-            continue;
-          }
-  
-          if (!isEqual(original[key], value)) {
-            changedKeys.push(key);
-          }
-        }
-      }
-      */
-  }
-}
-/**
-  Calculate the changed keys from prior and new `data`s.  This follows similar
-  semantics to `InternalModel._changedKeys`.
-  The key difference is that omitted attributes and new attributes are treated
-  as changes, instead of ignored.
-  There is another difference, which is that there's no notion of
-  `_inflightAttributes` or `_attributes`, but this will likely need to change
-  when m3 composes a write story.
-*/
-function calculateChangedKeys(oldValue, newValue) {
-  let oldKeys = Object.keys(oldValue).sort();
-  let newKeys = Object.keys(newValue).sort();
-  // omitted keys are treated as changes
-  let result = setDiff(oldKeys, newKeys);
-
-  for (let i = 0; i < newKeys.length; ++i) {
-    let key = newKeys[i];
-    if (!isEqual(oldValue[key], newValue[key])) {
-      result.push(key);
-    }
-  }
-
-  return result;
 }

--- a/addon/model.js
+++ b/addon/model.js
@@ -5,7 +5,7 @@ import { dasherize } from '@ember/string';
 import M3ModelData from './model-data';
 import SchemaManager from './schema-manager';
 import M3RecordArray from './record-array';
-import { OWNER_KEY } from './util';
+import { OWNER_KEY, isEmbeddedObject } from './util';
 
 const { get, set, propertyWillChange, propertyDidChange, computed, A } = Ember;
 
@@ -280,7 +280,7 @@ export default class MegamorphicModel extends Ember.Object {
 
       let oldIsRecordArray = oldValue && oldValue instanceof M3RecordArray;
       let oldWasModel = oldValue && oldValue instanceof MegamorphicModel;
-      let newIsObject = typeof newValue === 'object';
+      let newIsObject = isEmbeddedObject(newValue);
 
       if (oldWasModel && newIsObject) {
         oldValue._didReceiveNestedProperties(

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1973,7 +1973,7 @@ module('unit/model', function(hooks) {
       model.save().then(() => {
         assert.equal(model.get('isSaving'), false, 'model done saving');
         assert.deepEqual(
-          model._internalModel._data,
+          model._internalModel._modelData._data,
           {
             name: 'The Winds of Winter',
             estimatedRating: '11/10',
@@ -2206,7 +2206,7 @@ module('unit/model', function(hooks) {
       'after rolling back model.state loaded.saved'
     );
     assert.deepEqual(
-      model._internalModel._data,
+      model._internalModel._modelData._data,
       {
         // We do not error, but we also do not actually support rolling back
         // attributes


### PR DESCRIPTION
This is restoring the merge strategy for model data branch.

The tests are passing except handling `null` for nested models. Based on our discussion, making these tests pass will require the nested model data to be registered with the parent model data to be able to delegate merging the data if there is a nested model data for this data.