### PR TITLE
[Projection Support] Initial work for cache consistency and property invalidation

### DIFF
--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -51,18 +51,16 @@ export function extendStore(Store) {
     _preloadSingleResource(data) {
       let modelName = dasherize(data.type);
       let modelData = this.modelDataFor(modelName, data.id);
-      let isUpdate = false;
-      // let isUpdate = modelData.currentState.isEmpty === false;
 
-      // TODO All other uses of setupData notifies the record of any
-      // properties changes, but not this one. Temporary we have an
-      // explicit parameter to make setupData notify the record as well
-      modelData.setupData(data, true, true);
+      let changedKeys = modelData.setupData(data, true, true);
 
-      if (isUpdate === true) {
-        // this.recordArrayManager.recordDidChange(modelData);
-      } else {
-        // internalModel.currentState = EmptyState;
+      // We need to explicitly notify any possible record, which may have been associated
+      // with the preloaded ModelData. We don't delegate this to InternalModel
+      // to not confuse the implementation whether the `setupData` call also means
+      // it has been loaded
+      let internalModel = this._internalModelForId(modelName, data.id);
+      if (internalModel && internalModel.hasRecord) {
+        internalModel._record._notifyProperties(changedKeys);
       }
     },
 

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -54,7 +54,10 @@ export function extendStore(Store) {
       let isUpdate = false;
       // let isUpdate = modelData.currentState.isEmpty === false;
 
-      modelData.setupData(data);
+      // TODO All other uses of setupData notifies the record of any
+      // properties changes, but not this one. Temporary we have an
+      // explicit parameter to make setupData notify the record as well
+      modelData.setupData(data, true, true);
 
       if (isUpdate === true) {
         // this.recordArrayManager.recordDidChange(modelData);

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -52,7 +52,7 @@ export function extendStore(Store) {
       let modelName = dasherize(data.type);
       let modelData = this.modelDataFor(modelName, data.id);
 
-      let changedKeys = modelData.setupData(data, true, true);
+      let changedKeys = modelData.setupData(data, true);
 
       // We need to explicitly notify any possible record, which may have been associated
       // with the preloaded ModelData. We don't delegate this to InternalModel

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -5,10 +5,7 @@ import SchemaManager from './schema-manager';
 const { isEqual } = Ember;
 
 function setupDataAndNotify(modelData, updates) {
-  let changedKeys = modelData.setupData(
-    { attributes: updates },
-    modelData.internalModel.hasRecord
-  );
+  let changedKeys = modelData.setupData({ attributes: updates });
 
   modelData._notifyRecordProperties(changedKeys);
 }
@@ -46,16 +43,12 @@ export default class M3ModelData {
 
   // PUBLIC API
 
-  setupData(data, calculateChanges, notify) {
+  setupData(data) {
     // TODO One more parameter is used to indicate we need setupData to
     // also notify records of any changes, because preload does not do
     // it, but it should
     let changedKeys = this._mergeUpdates(data.attributes, setupDataAndNotify);
     this._notifyProjectionProperties(changedKeys);
-
-    if (notify) {
-      this._notifyRecordProperties(changedKeys);
-    }
 
     return changedKeys;
   }

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { isEmbeddedObject } from './util';
+import SchemaManager from './schema-manager';
 
 const { isEqual } = Ember;
 
@@ -30,6 +31,14 @@ export default class M3ModelData {
     this.__implicitRelationships = Object.create(null);
     this.__data = null;
     this.__nestedModelsData = null;
+    this._schema = SchemaManager;
+
+    this.baseModelName = this._schema.computeBaseModelName(this.modelName);
+
+    // TODO we may not have ID yet?
+    this.baseModelData = this.baseModelName
+      ? store.modelDataFor(this.baseModelName, id)
+      : null;
   }
 
   // PUBLIC API
@@ -50,7 +59,10 @@ export default class M3ModelData {
 
   // TODO, Maybe can model as destroying model data?
   resetRecord() {
-    this._data = null;
+    if (this.baseModelData === null) {
+      // only reset the data if it is not a projection
+      this._data = null;
+    }
   }
 
   /*
@@ -213,13 +225,23 @@ export default class M3ModelData {
   }
 
   get _data() {
+    if (this.baseModelData !== null) {
+      return this.baseModelData._data;
+    }
+
     if (this.__data === null) {
       this.__data = Object.create(null);
     }
+
     return this.__data;
   }
 
   set _data(v) {
+    if (this.baseModelData !== null) {
+      this.baseModelData._data = v;
+      return;
+    }
+
     this.__data = v;
   }
 
@@ -258,6 +280,10 @@ export default class M3ModelData {
   }
 
   get _inFlightAttributes() {
+    if (this.baseModelData !== null) {
+      return this.baseModelData._inFlightAttributes;
+    }
+
     if (this.__inFlightAttributes === null) {
       this.__inFlightAttributes = Object.create(null);
     }
@@ -265,6 +291,11 @@ export default class M3ModelData {
   }
 
   set _inFlightAttributes(v) {
+    if (this.baseModelData !== null) {
+      this.baseModelData._inFlightAttributes = v;
+      return;
+    }
+
     this.__inFlightAttributes = v;
   }
 

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -320,26 +320,6 @@ export default class M3ModelData {
     return this.__implicitRelationships;
   }
 
-  get _inFlightAttributes() {
-    if (this.baseModelData !== null) {
-      return this.baseModelData._inFlightAttributes;
-    }
-
-    if (this.__inFlightAttributes === null) {
-      this.__inFlightAttributes = Object.create(null);
-    }
-    return this.__inFlightAttributes;
-  }
-
-  set _inFlightAttributes(v) {
-    if (this.baseModelData !== null) {
-      this.baseModelData._inFlightAttributes = v;
-      return;
-    }
-
-    this.__inFlightAttributes = v;
-  }
-
   get _nestedModelDatas() {
     if (this.__nestedModelsData === null) {
       this.__nestedModelsData = Object.create(null);

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -44,9 +44,6 @@ export default class M3ModelData {
   // PUBLIC API
 
   setupData(data) {
-    // TODO One more parameter is used to indicate we need setupData to
-    // also notify records of any changes, because preload does not do
-    // it, but it should
     let changedKeys = this._mergeUpdates(data.attributes, setupDataAndNotify);
     this._notifyProjectionProperties(changedKeys);
 

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -46,15 +46,17 @@ export default class M3ModelData {
 
   // PUBLIC API
 
-  setupData(data, calculateChanges) {
-    let changedKeys = this._mergeUpdates(
-      data.attributes,
-      setupDataAndNotify,
-      calculateChanges
-    );
-    if (calculateChanges) {
-      this._notifyProjectionProperties(changedKeys);
+  setupData(data, calculateChanges, notify) {
+    // TODO One more parameter is used to indicate we need setupData to
+    // also notify records of any changes, because preload does not do
+    // it, but it should
+    let changedKeys = this._mergeUpdates(data.attributes, setupDataAndNotify);
+    this._notifyProjectionProperties(changedKeys);
+
+    if (notify) {
+      this._notifyRecordProperties(changedKeys);
     }
+
     return changedKeys;
   }
 
@@ -188,13 +190,10 @@ export default class M3ModelData {
    * @returns {Array}
    * @private
    */
-  _mergeUpdates(updates, nestedCallback, calculateChanges = true) {
+  _mergeUpdates(updates, nestedCallback) {
     let data = this._data;
 
-    let changedKeys;
-    if (calculateChanges) {
-      changedKeys = [];
-    }
+    let changedKeys = [];
 
     if (!updates) {
       // no changes
@@ -225,9 +224,7 @@ export default class M3ModelData {
         this.destroyNestedModelData(key);
       }
 
-      if (calculateChanges) {
-        changedKeys.push(key);
-      }
+      changedKeys.push(key);
       data[key] = newValue;
     }
 

--- a/addon/model.js
+++ b/addon/model.js
@@ -504,6 +504,12 @@ export default class MegamorphicModel extends Ember.Object {
       return;
     }
 
+    if (!this._schema.isAttributeIncluded(this._modelName, key)) {
+      throw new Error(
+        `Cannot set non-whitelisted property ${key} on type ${this._modelName}`
+      );
+    }
+
     if (this._schema.getAttributeAlias(this._modelName, key)) {
       throw new Error(
         `You tried to set '${key}' to '${value}', but '${key}' is an alias in '${

--- a/addon/model.js
+++ b/addon/model.js
@@ -328,6 +328,9 @@ export default class MegamorphicModel extends Ember.Object {
       let key;
       for (let i = 0, length = keys.length; i < length; i++) {
         key = keys[i];
+        if (!this._schema.isAttributeIncluded(this._modelName, key)) {
+          continue;
+        }
         let oldValue = this._cache[key];
         let newValue = this._internalModel._modelData.getAttr(key);
 
@@ -519,7 +522,7 @@ export default class MegamorphicModel extends Ember.Object {
     if (this._schema.isAttributeArrayReference(key, value, this._modelName)) {
       this._setRecordArray(key, value);
     } else {
-      this._internalModel._modelData._data[key] = value;
+      this._internalModel._modelData.setAttr(key, value);
       delete this._cache[key];
     }
 
@@ -534,7 +537,7 @@ export default class MegamorphicModel extends Ember.Object {
       // TODO: should have a schema hook for this
       ids[i] = get(models.objectAt(i), 'id');
     }
-    this._internalModel._modelData._data[key] = ids;
+    this._internalModel._modelData.setAttr(key, ids);
 
     if (key in this._cache) {
       let recordArray = this._cache[key];

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -808,7 +808,7 @@ module('unit/projection', function(hooks) {
       this.records = null;
     });
 
-    skip('Setting on the base-record updates projections', function(assert) {
+    test('Setting on the base-record updates projections', function(assert) {
       let { baseRecord } = this.records;
 
       run(() => {

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2140,43 +2140,37 @@ module('unit/projection', function(hooks) {
       });
     });
 
-    skip(
-      `Unloading a projection does not unload the base-record and other projections`,
-      function(assert) {
-        let { baseRecord, projectedPreview, projectedExcerpt } = this.records;
+    test(`Unloading a projection does not unload the base-record and other projections`, function(assert) {
+      let { baseRecord, projectedPreview, projectedExcerpt } = this.records;
 
-        run(() => {
-          projectedPreview.unloadRecord();
-        });
+      run(() => {
+        projectedPreview.unloadRecord();
+      });
 
-        // projectedPreview has been unloaded
-        assert.equal(
-          this.store.hasRecordForId(projectedPreview, BOOK_ID),
-          false
-        );
-        assert.equal(get(projectedPreview, 'isDestroyed'), true);
+      // projectedPreview has been unloaded
+      assert.equal(
+        this.store.hasRecordForId(BOOK_PREVIEW_PROJECTION_CLASS_PATH, BOOK_ID),
+        false
+      );
+      assert.equal(get(projectedPreview, 'isDestroyed'), true);
 
-        // baseRecord is still around
-        assert.equal(this.store.hasRecordForId(baseRecord, BOOK_ID), true);
-        assert.equal(get(baseRecord, 'isDestroyed'), false);
-        // TODO How can we check whether the underlying structure were not destroyed in the case of unload
-        // Functionality can continue to work even in case of a bug
-        assert.equal(get(baseRecord, '_internalModel.isDestroyed'), false);
-        assert.equal(get(baseRecord, 'title'), BOOK_TITLE);
+      // baseRecord is still around
+      assert.equal(this.store.hasRecordForId(BOOK_CLASS_PATH, BOOK_ID), true);
+      assert.equal(get(baseRecord, 'isDestroyed'), false);
+      // TODO How can we check whether the underlying structure were not destroyed in the case of unload
+      // Functionality can continue to work even in case of a bug
+      assert.equal(get(baseRecord, '_internalModel.isDestroyed'), false);
+      assert.equal(get(baseRecord, 'title'), BOOK_TITLE);
 
-        // projectedExcerpt is still arond
-        assert.equal(
-          this.store.hasRecordForId(projectedExcerpt, BOOK_ID),
-          true
-        );
-        assert.equal(get(projectedExcerpt, 'isDestroyed'), false);
-        assert.equal(
-          get(projectedExcerpt, '_internalModel.isDestroyed'),
-          false
-        );
-        assert.equal(get(projectedExcerpt, 'title'), BOOK_TITLE);
-      }
-    );
+      // projectedExcerpt is still arond
+      assert.equal(
+        this.store.hasRecordForId(BOOK_EXCERPT_PROJECTION_CLASS_PATH, BOOK_ID),
+        true
+      );
+      assert.equal(get(projectedExcerpt, 'isDestroyed'), false);
+      assert.equal(get(projectedExcerpt, '_internalModel.isDestroyed'), false);
+      assert.equal(get(projectedExcerpt, 'title'), BOOK_TITLE);
+    });
 
     skip(`Unloading the base-record does not unload the projection`, function(
       assert
@@ -2188,11 +2182,14 @@ module('unit/projection', function(hooks) {
       });
 
       // baseRecord has been unloaded
-      assert.equal(this.store.hasRecordForId(baseRecord, BOOK_ID), false);
+      assert.equal(this.store.hasRecordForId(BOOK_CLASS_PATH, BOOK_ID), false);
       assert.equal(get(baseRecord, 'isDestroyed'), true);
 
       // projectedPreview is still around
-      assert.equal(this.store.hasRecordForId(projectedPreview, BOOK_ID), true);
+      assert.equal(
+        this.store.hasRecordForId(BOOK_PREVIEW_PROJECTION_CLASS_PATH, BOOK_ID),
+        true
+      );
       assert.equal(get(projectedPreview, 'isDestroyed'), false);
       // TODO How can we check whether the underlying structure were not destroyed in the case of unload
       // Functionality can continue to work even in case of a bug

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1740,155 +1740,19 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip(
-      'Updating a resolution property via the base-record updates projections and nested projections',
-      function(assert) {
-        let { store } = this;
-        let { baseRecord, projectedExcerpt } = this.records;
+    test('Updating a resolution property via the base-record updates projections and nested projections', function(assert) {
+      let { store } = this;
+      let { baseRecord, projectedExcerpt } = this.records;
 
-        run(() => {
-          store.push({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_CLASS_PATH,
-              attributes: {},
-            },
-            included: [
-              {
-                id: PUBLISHER_ID,
-                type: PUBLISHER_CLASS,
-                attributes: {
-                  location: NEW_PUBLISHER_LOCATION,
-                  owner: NEW_PUBLISHER_OWNER,
-                },
-              },
-            ],
-          });
-        });
-
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
-
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
-
-        assert.watchedPropertyCount(
-          baseCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.description'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.description'
-        );
-        assert.equal(
-          get(baseRecord, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'base-record has the correct publisher.owner'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'excerpt has the correct publisher.owner'
-        );
-      }
-    );
-
-    skip(
-      'Setting a resolution property via a projection updates the base-record, other projections and nested projections',
-      function(assert) {
-        let { baseRecord, projectedExcerpt } = this.records;
-
-        run(() => {
-          set(projectedExcerpt, 'publisher.location', NEW_PUBLISHER_LOCATION);
-          set(projectedExcerpt, 'publisher.owner', NEW_PUBLISHER_OWNER);
-        });
-
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
-
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
-
-        assert.watchedPropertyCount(
-          baseCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.publisher.owner'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.publisher.owner'
-        );
-        assert.equal(
-          get(baseRecord, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'base-record has the correct publisher.owner'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'excerpt has the correct publisher.owner'
-        );
-      }
-    );
-
-    skip(
-      'Setting a resolution property via a nested projection updates the base-record and other projections',
-      function(assert) {
-        let { baseRecord, projectedExcerpt, projectedPreview } = this.records;
-
-        run(() => {
-          set(projectedPreview, 'publisher.location', NEW_PUBLISHER_LOCATION);
-        });
-
-        assert.throws(
-          () => {
-            run(() => {
-              set(projectedPreview, 'publisher.owner', NEW_PUBLISHER_OWNER);
-            });
+      run(() => {
+        store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {},
           },
-          /whitelist/gi,
-          'Setting a non-whitelisted property on a projection over a resolved record throws an error'
-        );
-
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
-
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
-
-        assert.watchedPropertyCount(
-          baseCounters['publisher.owner'],
-          0,
-          'Afterwards we have not dirtied baseRecord.publisher.owner'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['publisher.owner'],
-          0,
-          'Afterwards we have not  dirtied baseRecord.publisher.owner'
-        );
-        assert.equal(
-          get(baseRecord, 'publisher.owner'),
-          PUBLISHER_OWNER,
-          'base-record has the correct publisher.owner'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'publisher.owner'),
-          PUBLISHER_OWNER,
-          'excerpt has the correct publisher.owner'
-        );
-      }
-    );
-
-    skip(
-      'Updating a resolution property via a projection updates the base-record, other projections and nested projections',
-      function(assert) {
-        let { store } = this;
-
-        let { baseRecord, projectedExcerpt } = this.records;
-
-        run(() => {
-          store.preloadData({
-            data: {
+          included: [
+            {
               id: PUBLISHER_ID,
               type: PUBLISHER_CLASS,
               attributes: {
@@ -1896,112 +1760,233 @@ module('unit/projection', function(hooks) {
                 owner: NEW_PUBLISHER_OWNER,
               },
             },
+          ],
+        });
+      });
+
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
+
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
+
+      assert.watchedPropertyCount(
+        baseCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.description'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.description'
+      );
+      assert.equal(
+        get(baseRecord, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'base-record has the correct publisher.owner'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'excerpt has the correct publisher.owner'
+      );
+    });
+
+    test('Setting a resolution property via a projection updates the base-record, other projections and nested projections', function(assert) {
+      let { baseRecord, projectedExcerpt } = this.records;
+
+      run(() => {
+        set(projectedExcerpt, 'publisher.location', NEW_PUBLISHER_LOCATION);
+        set(projectedExcerpt, 'publisher.owner', NEW_PUBLISHER_OWNER);
+      });
+
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
+
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
+
+      assert.watchedPropertyCount(
+        baseCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.publisher.owner'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.publisher.owner'
+      );
+      assert.equal(
+        get(baseRecord, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'base-record has the correct publisher.owner'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'excerpt has the correct publisher.owner'
+      );
+    });
+
+    test('Setting a resolution property via a nested projection updates the base-record and other projections', function(assert) {
+      let { baseRecord, projectedExcerpt, projectedPreview } = this.records;
+
+      run(() => {
+        set(projectedPreview, 'publisher.location', NEW_PUBLISHER_LOCATION);
+      });
+
+      assert.throws(
+        () => {
+          run(() => {
+            set(projectedPreview, 'publisher.owner', NEW_PUBLISHER_OWNER);
           });
-          store.push({
-            data: {
+        },
+        /whitelist/gi,
+        'Setting a non-whitelisted property on a projection over a resolved record throws an error'
+      );
+
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
+
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
+
+      assert.watchedPropertyCount(
+        baseCounters['publisher.owner'],
+        0,
+        'Afterwards we have not dirtied baseRecord.publisher.owner'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['publisher.owner'],
+        0,
+        'Afterwards we have not  dirtied baseRecord.publisher.owner'
+      );
+      assert.equal(
+        get(baseRecord, 'publisher.owner'),
+        PUBLISHER_OWNER,
+        'base-record has the correct publisher.owner'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'publisher.owner'),
+        PUBLISHER_OWNER,
+        'excerpt has the correct publisher.owner'
+      );
+    });
+
+    test('Updating a resolution property via a projection updates the base-record, other projections and nested projections', function(assert) {
+      let { store } = this;
+
+      let { baseRecord, projectedExcerpt } = this.records;
+
+      run(() => {
+        store.preloadData({
+          data: {
+            id: PUBLISHER_ID,
+            type: PUBLISHER_CLASS,
+            attributes: {
+              location: NEW_PUBLISHER_LOCATION,
+              owner: NEW_PUBLISHER_OWNER,
+            },
+          },
+        });
+        store.push({
+          data: {
+            id: PUBLISHER_ID,
+            type: PROJECTED_PUBLISHER_CLASS,
+            attributes: {},
+          },
+        });
+      });
+
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
+
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
+
+      assert.watchedPropertyCount(
+        baseCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.description'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.description'
+      );
+      assert.equal(
+        get(baseRecord, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'base-record has the correct publisher.owner'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'excerpt has the correct publisher.owner'
+      );
+    });
+
+    test('Updating a resolution property via a nested projection updates the base-record, other projections', function(assert) {
+      let { store } = this;
+      let { baseRecord, projectedExcerpt } = this.records;
+
+      run(() => {
+        store.preloadData({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {
+              publisher: PUBLISHER_URN,
+            },
+          },
+          included: [
+            {
+              id: PUBLISHER_ID,
+              type: PUBLISHER_CLASS,
+              attributes: {
+                location: NEW_PUBLISHER_LOCATION,
+              },
+            },
+          ],
+        });
+        store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            attributes: {},
+          },
+          included: [
+            {
               id: PUBLISHER_ID,
               type: PROJECTED_PUBLISHER_CLASS,
               attributes: {},
             },
-          });
+          ],
         });
+      });
 
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
 
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
 
-        assert.watchedPropertyCount(
-          baseCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.description'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.description'
-        );
-        assert.equal(
-          get(baseRecord, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'base-record has the correct publisher.owner'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'excerpt has the correct publisher.owner'
-        );
-      }
-    );
-
-    skip(
-      'Updating a resolution property via a nested projection updates the base-record, other projections',
-      function(assert) {
-        let { store } = this;
-        let { baseRecord, projectedExcerpt } = this.records;
-
-        run(() => {
-          store.preloadData({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_CLASS_PATH,
-              attributes: {
-                publisher: PUBLISHER_URN,
-              },
-            },
-            included: [
-              {
-                id: PUBLISHER_ID,
-                type: PUBLISHER_CLASS,
-                attributes: {
-                  location: NEW_PUBLISHER_LOCATION,
-                },
-              },
-            ],
-          });
-          store.push({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-              attributes: {},
-            },
-            included: [
-              {
-                id: PUBLISHER_ID,
-                type: PROJECTED_PUBLISHER_CLASS,
-                attributes: {},
-              },
-            ],
-          });
-        });
-
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
-
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
-
-        assert.watchedPropertyCount(
-          baseCounters['publisher.owner'],
-          0,
-          'Afterwards we have not dirtied baseRecord.publisher.owner'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['publisher.owner'],
-          0,
-          'Afterwards we have not  dirtied baseRecord.publisher.owner'
-        );
-        assert.equal(
-          get(baseRecord, 'publisher.owner'),
-          PUBLISHER_OWNER,
-          'base-record has the correct publisher.owner'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'publisher.owner'),
-          PUBLISHER_OWNER,
-          'excerpt has the correct publisher.owner'
-        );
-      }
-    );
+      assert.watchedPropertyCount(
+        baseCounters['publisher.owner'],
+        0,
+        'Afterwards we have not dirtied baseRecord.publisher.owner'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['publisher.owner'],
+        0,
+        'Afterwards we have not  dirtied baseRecord.publisher.owner'
+      );
+      assert.equal(
+        get(baseRecord, 'publisher.owner'),
+        PUBLISHER_OWNER,
+        'base-record has the correct publisher.owner'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'publisher.owner'),
+        PUBLISHER_OWNER,
+        'excerpt has the correct publisher.owner'
+      );
+    });
   });
 
   skip(

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -833,7 +833,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip('Updating the base-record updates projections', function(assert) {
+    test('Updating the base-record updates projections', function(assert) {
       let { store } = this;
       let { baseRecord } = this.records;
 
@@ -867,77 +867,71 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip(
-      'Setting a projection updates the base-record and other projections',
-      function(assert) {
-        let preview = this.records.projectedPreview;
-        let baseRecord = this.records.baseRecord;
+    test('Setting a projection updates the base-record and other projections', function(assert) {
+      let preview = this.records.projectedPreview;
+      let baseRecord = this.records.baseRecord;
 
-        run(() => {
-          set(preview, 'chapter-1', NEW_CHAPTER_TEXT);
-          set(preview, 'title', NEW_TITLE);
-        });
+      run(() => {
+        set(preview, 'chapter-1', NEW_CHAPTER_TEXT);
+        set(preview, 'title', NEW_TITLE);
+      });
 
-        assert.throws(
-          () => {
-            run(() => {
-              set(preview, 'description', NEW_DESCRIPTION);
-            });
+      assert.throws(
+        () => {
+          run(() => {
+            set(preview, 'description', NEW_DESCRIPTION);
+          });
+        },
+        /whitelist/gi,
+        'Setting a non-whitelisted property throws an error'
+      );
+      assert.watchedPropertyCount(
+        this.watchers.baseRecordWatcher.counters.description,
+        0,
+        'Afterwards we have not dirtied baseRecord.description'
+      );
+      assert.equal(
+        get(baseRecord, 'description'),
+        BOOK_DESCRIPTION,
+        'base-record has the correct description'
+      );
+    });
+
+    test('Updating a projection updates the base-record and other projections', function(assert) {
+      let baseRecord = this.records.baseRecord;
+      let { store } = this;
+
+      run(() => {
+        store.preloadData({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {
+              title: NEW_TITLE,
+              'chapter-1': NEW_CHAPTER_TEXT,
+            },
           },
-          /whitelist/gi,
-          'Setting a non-whitelisted property throws an error'
-        );
-        assert.watchedPropertyCount(
-          this.watchers.baseRecordWatcher.counters.description,
-          0,
-          'Afterwards we have not dirtied baseRecord.description'
-        );
-        assert.equal(
-          get(baseRecord, 'description'),
-          BOOK_DESCRIPTION,
-          'base-record has the correct description'
-        );
-      }
-    );
-
-    skip(
-      'Updating a projection updates the base-record and other projections',
-      function(assert) {
-        let baseRecord = this.records.baseRecord;
-        let { store } = this;
-
-        run(() => {
-          store.preloadData({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_CLASS_PATH,
-              attributes: {
-                title: NEW_TITLE,
-                'chapter-1': NEW_CHAPTER_TEXT,
-              },
-            },
-          });
-          store.push({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-              attributes: {},
-            },
-          });
         });
+        store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            attributes: {},
+          },
+        });
+      });
 
-        assert.watchedPropertyCount(
-          this.watchers.baseRecordWatcher.counters.description,
-          0,
-          'Afterwards we have not dirtied baseRecord.description'
-        );
-        assert.equal(
-          get(baseRecord, 'description'),
-          BOOK_DESCRIPTION,
-          'base-record has the correct description'
-        );
-      }
-    );
+      assert.watchedPropertyCount(
+        this.watchers.baseRecordWatcher.counters.description,
+        0,
+        'Afterwards we have not dirtied baseRecord.description'
+      );
+      assert.equal(
+        get(baseRecord, 'description'),
+        BOOK_DESCRIPTION,
+        'base-record has the correct description'
+      );
+    });
   });
 
   module('property notifications on embedded objects', function(hooks) {
@@ -1711,43 +1705,40 @@ module('unit/projection', function(hooks) {
       this.records = null;
     });
 
-    skip(
-      'Setting a resolution property via the base-record updates projections and nested projections',
-      function(assert) {
-        let { baseRecord, projectedExcerpt } = this.records;
+    test('Setting a resolution property via the base-record updates projections and nested projections', function(assert) {
+      let { baseRecord, projectedExcerpt } = this.records;
 
-        run(() => {
-          set(baseRecord, 'publisher.location', NEW_PUBLISHER_LOCATION);
-          set(baseRecord, 'publisher.owner', NEW_PUBLISHER_OWNER);
-        });
+      run(() => {
+        set(baseRecord, 'publisher.location', NEW_PUBLISHER_LOCATION);
+        set(baseRecord, 'publisher.owner', NEW_PUBLISHER_OWNER);
+      });
 
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
 
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
 
-        assert.watchedPropertyCount(
-          baseCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.description'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['publisher.owner'],
-          1,
-          'Afterwards we have dirtied baseRecord.description'
-        );
-        assert.equal(
-          get(baseRecord, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'base-record has the correct publisher.owner'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'publisher.owner'),
-          NEW_PUBLISHER_OWNER,
-          'excerpt has the correct publisher.owner'
-        );
-      }
-    );
+      assert.watchedPropertyCount(
+        baseCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.description'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['publisher.owner'],
+        1,
+        'Afterwards we have dirtied baseRecord.description'
+      );
+      assert.equal(
+        get(baseRecord, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'base-record has the correct publisher.owner'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'publisher.owner'),
+        NEW_PUBLISHER_OWNER,
+        'excerpt has the correct publisher.owner'
+      );
+    });
 
     skip(
       'Updating a resolution property via the base-record updates projections and nested projections',

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2286,111 +2286,97 @@ module('unit/projection', function(hooks) {
     const BOOK_CHAPTER_1 = 'Down the Rabbit-Hole';
     const BOOK_CHAPTER_2 = 'Looking-Glass House';
 
-    skip(
-      'independently created projections of the same base-type but no ID do not share their data',
-      function(assert) {
-        let projectedPreview = this.store.createRecord(
-          BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-          {
-            title: BOOK_TITLE_1,
-          }
-        );
-        let projectedExcerpt = this.store.createRecord(
-          BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-          {
-            title: BOOK_TITLE_2,
-          }
-        );
+    test('independently created projections of the same base-type but no ID do not share their data', function(assert) {
+      let projectedPreview = run(() =>
+        this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
+          title: BOOK_TITLE_1,
+        })
+      );
+      let projectedExcerpt = run(() =>
+        this.store.createRecord(BOOK_EXCERPT_PROJECTION_CLASS_PATH, {
+          title: BOOK_TITLE_2,
+        })
+      );
 
-        assert.equal(
-          get(projectedPreview, 'title'),
-          BOOK_TITLE_1,
-          'Expected title of preview projection to be correct'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'title'),
-          BOOK_TITLE_2,
-          'Expected title of excerpt projection to be correct'
-        );
-      }
-    );
+      assert.equal(
+        get(projectedPreview, 'title'),
+        BOOK_TITLE_1,
+        'Expected title of preview projection to be correct'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'title'),
+        BOOK_TITLE_2,
+        'Expected title of excerpt projection to be correct'
+      );
+    });
 
-    skip(
-      'independently created projections of the same projection-type but no ID do not share their data',
-      function(assert) {
-        let projectedPreview1 = this.store.createRecord(
-          BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-          {
-            title: BOOK_TITLE_1,
-          }
-        );
-        let projectedPreview2 = this.store.createRecord(
-          BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-          {
-            title: BOOK_TITLE_2,
-          }
-        );
+    test('independently created projections of the same projection-type but no ID do not share their data', function(assert) {
+      let projectedPreview1 = run(() =>
+        this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
+          title: BOOK_TITLE_1,
+        })
+      );
+      let projectedPreview2 = run(() =>
+        this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
+          title: BOOK_TITLE_2,
+        })
+      );
 
-        assert.equal(
-          get(projectedPreview1, 'title'),
-          BOOK_TITLE_1,
-          'Expected title of preview projection to be correct'
-        );
-        assert.equal(
-          get(projectedPreview2, 'title'),
-          BOOK_TITLE_2,
-          'Expected title of the second preview projection to be correct'
-        );
-      }
-    );
+      assert.equal(
+        get(projectedPreview1, 'title'),
+        BOOK_TITLE_1,
+        'Expected title of preview projection to be correct'
+      );
+      assert.equal(
+        get(projectedPreview2, 'title'),
+        BOOK_TITLE_2,
+        'Expected title of the second preview projection to be correct'
+      );
+    });
 
-    skip(
-      'independently created projections of the same base-type and ID share their data',
-      function(assert) {
-        let projectedPreview = this.store.createRecord(
-          BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-          {
-            id: BOOK_ID,
-            title: BOOK_TITLE_1,
-          }
-        );
-        let projectedExcerpt = this.store.createRecord(
-          BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-          {
-            id: BOOK_ID,
-            title: BOOK_TITLE_2,
-          }
-        );
+    test('independently created projections of the same base-type and ID share their data', function(assert) {
+      let projectedPreview = run(() =>
+        this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
+          id: BOOK_ID,
+          title: BOOK_TITLE_1,
+        })
+      );
+      let projectedExcerpt = run(() =>
+        this.store.createRecord(BOOK_EXCERPT_PROJECTION_CLASS_PATH, {
+          id: BOOK_ID,
+          title: BOOK_TITLE_2,
+        })
+      );
 
-        assert.equal(
-          get(projectedPreview, 'title'),
-          BOOK_TITLE_2,
-          'Expected title of preview projection to be correct'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'title'),
-          BOOK_TITLE_2,
-          'Expected title of excerpt projection to be correct'
-        );
+      assert.equal(
+        get(projectedPreview, 'title'),
+        BOOK_TITLE_2,
+        'Expected title of preview projection to be correct'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'title'),
+        BOOK_TITLE_2,
+        'Expected title of excerpt projection to be correct'
+      );
 
+      run(() => {
         set(projectedExcerpt, 'title', BOOK_TITLE_1);
+      });
 
-        assert.equal(
-          get(projectedPreview, 'title'),
-          BOOK_TITLE_1,
-          'Expected title of preview projection to be updated'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'title'),
-          BOOK_TITLE_1,
-          'Expected title of excerpt projection to be updated'
-        );
-      }
-    );
+      assert.equal(
+        get(projectedPreview, 'title'),
+        BOOK_TITLE_1,
+        'Expected title of preview projection to be updated'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'title'),
+        BOOK_TITLE_1,
+        'Expected title of excerpt projection to be updated'
+      );
+    });
 
-    skip(
-      'independently creating projections of the same projection-type and ID is not allowed',
-      function(assert) {
+    test('independently creating projections of the same projection-type and ID is not allowed', function(assert) {
+      run(() => {
         this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
           id: BOOK_ID,
         });
@@ -2400,13 +2386,13 @@ module('unit/projection', function(hooks) {
               id: BOOK_ID,
             });
           },
-          /exist/,
+          /has already been used/,
           'Expected create record for same projection and ID to throw an error'
         );
-      }
-    );
+      });
+    });
 
-    skip('we can create and save a projection', function(assert) {
+    test('we can create and save a projection', function(assert) {
       let createRecordCalls = 0;
 
       this.owner.register(
@@ -2442,33 +2428,35 @@ module('unit/projection', function(hooks) {
         })
       );
 
-      let projectedPreview = this.store.createRecord(
-        BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-        {
-          title: BOOK_TITLE_1,
-        }
-      );
-
-      return projectedPreview.save().then(() => {
-        assert.equal(
-          get(projectedPreview, 'isNew'),
-          false,
-          'Expected the projection to be marked as saved'
+      let projectedPreview = run(() => {
+        let record = this.store.createRecord(
+          BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+          {
+            title: BOOK_TITLE_1,
+          }
         );
-        assert.equal(
-          get(projectedPreview, 'id'),
-          BOOK_ID,
-          'Expected the new record to have picked up the returned ID'
-        );
-        assert.equal(
-          createRecordCalls,
-          1,
-          'Expected `createRecord` to have been called exactly once.'
-        );
+        record.save();
+        return record;
       });
+
+      assert.equal(
+        get(projectedPreview, 'isNew'),
+        false,
+        'Expected the projection to be marked as saved'
+      );
+      assert.equal(
+        get(projectedPreview, 'id'),
+        BOOK_ID,
+        'Expected the new record to have picked up the returned ID'
+      );
+      assert.equal(
+        createRecordCalls,
+        1,
+        'Expected `createRecord` to have been called exactly once.'
+      );
     });
 
-    skip('new projections are correctly cached after save', function(assert) {
+    test('new projections are correctly cached after save', function(assert) {
       this.owner.register(
         'adapter:-ember-m3',
         Ember.Object.extend({
@@ -2491,15 +2479,15 @@ module('unit/projection', function(hooks) {
         })
       );
 
-      let projectedPreview = this.store.createRecord(
-        BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-        {
-          title: BOOK_TITLE_1,
-        }
-      );
-
-      run(() => {
-        projectedPreview.save();
+      let projectedPreview = run(() => {
+        let record = this.store.createRecord(
+          BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+          {
+            title: BOOK_TITLE_1,
+          }
+        );
+        record.save();
+        return record;
       });
 
       let peekedPreview = run(() => {
@@ -2545,15 +2533,16 @@ module('unit/projection', function(hooks) {
         })
       );
 
-      let projectedPreview = this.store.createRecord(
-        BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-        {
-          title: BOOK_TITLE_1,
-        }
-      );
+      let projectedPreview = run(() => {
+        let record = this.store.createRecord(
+          BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+          {
+            title: BOOK_TITLE_1,
+          }
+        );
 
-      run(() => {
-        projectedPreview.save();
+        record.save();
+        return record;
       });
 
       // instead of involving adapter, just push the data and check things were correctly updated

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1,4 +1,4 @@
-import { module, skip } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import Ember from 'ember';
 import MegamorphicModel from 'ember-m3/model';
@@ -139,16 +139,14 @@ module('unit/projection', function(hooks) {
   });
 
   module('cache consistency', function() {
-    skip(
-      `store.peekRecord() will only return a projection or base-record if it has been fetched`,
-      function(assert) {
-        assert.expect(4);
+    test(`store.peekRecord() will only return a projection or base-record if it has been fetched`, function(assert) {
+      assert.expect(4);
 
-        const UNFETCHED_PROJECTION_ID = 'isbn:9780439708180';
-        const FETCHED_PROJECTION_ID = 'isbn:9780439708181';
-        let { store } = this;
+      const UNFETCHED_PROJECTION_ID = 'isbn:9780439708180';
+      const FETCHED_PROJECTION_ID = 'isbn:9780439708181';
+      let { store } = this;
 
-        /*
+      /*
         populate the store with a starting state of
          a base-record for the UNFETCHED_PROJECTION_ID and a projected-record
          for the FETCHED_PROJECTION_ID
@@ -157,120 +155,119 @@ module('unit/projection', function(hooks) {
           the FETCHED_PROJECTION_ID is the unfetched base-record
           the UNFETCHED_PROJECTION_ID is the already fetched base-record
         */
-        run(() => {
-          store.push({
-            data: {
-              type: BOOK_CLASS_PATH,
-              id: UNFETCHED_PROJECTION_ID,
-              attributes: {
-                title: 'Carry On! Mr. Bowditch',
-              },
+      run(() => {
+        store.push({
+          data: {
+            type: BOOK_CLASS_PATH,
+            id: UNFETCHED_PROJECTION_ID,
+            attributes: {
+              title: 'Carry On! Mr. Bowditch',
             },
-          });
-          store.preloadData({
-            data: {
-              type: BOOK_CLASS_PATH,
-              id: FETCHED_PROJECTION_ID,
-              attributes: {
-                title: `Mr. Popper's Penguins`,
-              },
-            },
-          });
-          store.push({
-            data: {
-              type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-              id: FETCHED_PROJECTION_ID,
-              attributes: {},
-            },
-          });
+          },
         });
+        store.preloadData({
+          data: {
+            type: BOOK_CLASS_PATH,
+            id: FETCHED_PROJECTION_ID,
+            attributes: {
+              title: `Mr. Popper's Penguins`,
+            },
+          },
+        });
+        store.push({
+          data: {
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            id: FETCHED_PROJECTION_ID,
+            attributes: {},
+          },
+        });
+      });
 
-        let projection = store.peekRecord(
-          BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-          UNFETCHED_PROJECTION_ID
-        );
-        assert.equal(
-          projection,
-          undefined,
-          'The unfetched projection with a fetched base-record is unfound by peekRecord()'
-        );
+      let projection = store.peekRecord(
+        BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+        UNFETCHED_PROJECTION_ID
+      );
 
-        projection = store.peekRecord(
-          BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-          FETCHED_PROJECTION_ID
-        );
-        assert.ok(
-          projection instanceof MegamorphicModel,
-          'The fetched projection is found by peekRecord()'
-        );
+      assert.equal(
+        projection,
+        null,
+        'The unfetched projection with a fetched base-record is unfound by peekRecord()'
+      );
 
-        let record = store.peekRecord(BOOK_CLASS_PATH, UNFETCHED_PROJECTION_ID);
-        assert.ok(
-          record instanceof MegamorphicModel,
-          'The fetched base-record is found by peekRecord()'
-        );
+      projection = store.peekRecord(
+        BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+        FETCHED_PROJECTION_ID
+      );
+      assert.ok(
+        projection instanceof MegamorphicModel,
+        'The fetched projection is found by peekRecord()'
+      );
 
-        record = store.peekRecord(BOOK_CLASS_PATH, FETCHED_PROJECTION_ID);
-        assert.equal(
-          record,
-          undefined,
-          'The unfetched base-record with a fetched projection is unfound by peekRecord()'
-        );
-      }
-    );
+      let record = store.peekRecord(BOOK_CLASS_PATH, UNFETCHED_PROJECTION_ID);
+      assert.ok(
+        record instanceof MegamorphicModel,
+        'The fetched base-record is found by peekRecord()'
+      );
 
-    skip(
-      `store.findRecord() will only fetch a projection or base-model if it has not been fetched previously`,
-      function(assert) {
-        assert.expect(12);
+      record = store.peekRecord(BOOK_CLASS_PATH, FETCHED_PROJECTION_ID);
 
-        const UNFETCHED_PROJECTION_ID = 'isbn:9780439708180';
-        const FETCHED_PROJECTION_ID = 'isbn:9780439708181';
-        let { store } = this;
+      assert.equal(
+        record,
+        null,
+        'The unfetched base-record with a fetched projection is unfound by peekRecord()'
+      );
+    });
 
-        let expectedFindRecordModelName;
-        let trueFindRecordModelName;
-        let expectedFindRecordId;
-        let findRecordCallCount = 0;
+    test(`store.findRecord() will only fetch a projection or base-model if it has not been fetched previously`, function(assert) {
+      assert.expect(12);
 
-        this.owner.register(
-          'adapter:-ember-m3',
-          Ember.Object.extend({
-            findRecord(store, modelClass, id, snapshot) {
-              findRecordCallCount++;
-              assert.equal(
-                snapshot.modelName,
-                expectedFindRecordModelName,
-                'findRecord snapshot has the correct modelName'
-              );
-              assert.equal(
-                id,
-                expectedFindRecordId,
-                'findRecord received the correct id'
-              );
+      const UNFETCHED_PROJECTION_ID = 'isbn:9780439708180';
+      const FETCHED_PROJECTION_ID = 'isbn:9780439708181';
+      let { store } = this;
 
-              return Promise.resolve({
-                data: {
-                  id: expectedFindRecordId,
-                  type: trueFindRecordModelName,
-                  attributes: {
-                    title: 'Carry on! Mr. Bowditch',
-                  },
+      let expectedFindRecordModelName;
+      let trueFindRecordModelName;
+      let expectedFindRecordId;
+      let findRecordCallCount = 0;
+
+      this.owner.register(
+        'adapter:-ember-m3',
+        Ember.Object.extend({
+          findRecord(store, modelClass, id, snapshot) {
+            findRecordCallCount++;
+            assert.equal(
+              snapshot.modelName,
+              expectedFindRecordModelName,
+              'findRecord snapshot has the correct modelName'
+            );
+            assert.equal(
+              id,
+              expectedFindRecordId,
+              'findRecord received the correct id'
+            );
+
+            return Promise.resolve({
+              data: {
+                id: expectedFindRecordId,
+                type: trueFindRecordModelName,
+                attributes: {
+                  title: 'Carry on! Mr. Bowditch',
                 },
-              });
-            },
+              },
+            });
+          },
 
-            shouldReloadRecord() {
-              return false;
-            },
+          shouldReloadRecord() {
+            return false;
+          },
 
-            shouldBackgroundReloadRecord() {
-              return false;
-            },
-          })
-        );
+          shouldBackgroundReloadRecord() {
+            return false;
+          },
+        })
+      );
 
-        /*
+      /*
         populate the store with a starting state of
          a base-record for the UNFETCHED_PROJECTION_ID and a projected-record
          for the FETCHED_PROJECTION_ID
@@ -279,119 +276,113 @@ module('unit/projection', function(hooks) {
           the FETCHED_PROJECTION_ID is the unfetched base-record
           the UNFETCHED_PROJECTION_ID is the already fetched base-record
         */
-        run(() => {
-          store.push({
-            data: {
-              type: BOOK_CLASS_PATH,
-              id: UNFETCHED_PROJECTION_ID,
-              attributes: {
-                title: 'Carry On! Mr. Bowditch',
-              },
+      run(() => {
+        store.push({
+          data: {
+            type: BOOK_CLASS_PATH,
+            id: UNFETCHED_PROJECTION_ID,
+            attributes: {
+              title: 'Carry On! Mr. Bowditch',
             },
-          });
-          store.preloadData({
-            data: {
-              type: BOOK_CLASS_PATH,
-              id: FETCHED_PROJECTION_ID,
-              attributes: {
-                title: `Mr. Popper's Penguins`,
-              },
-            },
-          });
-          store.push({
-            data: {
-              type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-              id: FETCHED_PROJECTION_ID,
-              attributes: {},
-            },
-          });
+          },
         });
+        store.preloadData({
+          data: {
+            type: BOOK_CLASS_PATH,
+            id: FETCHED_PROJECTION_ID,
+            attributes: {
+              title: `Mr. Popper's Penguins`,
+            },
+          },
+        });
+        store.push({
+          data: {
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            id: FETCHED_PROJECTION_ID,
+            attributes: {},
+          },
+        });
+      });
 
-        /*
+      /*
         Setup findRecord params for projection requests
 
         remember:
           the FETCHED_PROJECTION_ID is the unfetched base-record
           the UNFETCHED_PROJECTION_ID is the already fetched base-record
        */
-        findRecordCallCount = 0;
-        expectedFindRecordModelName = NORM_BOOK_EXCERPT_PROJECTION_CLASS_PATH;
-        trueFindRecordModelName = BOOK_EXCERPT_PROJECTION_CLASS_PATH;
-        expectedFindRecordId = UNFETCHED_PROJECTION_ID;
+      findRecordCallCount = 0;
+      expectedFindRecordModelName = NORM_BOOK_EXCERPT_PROJECTION_CLASS_PATH;
+      trueFindRecordModelName = BOOK_EXCERPT_PROJECTION_CLASS_PATH;
+      expectedFindRecordId = UNFETCHED_PROJECTION_ID;
 
-        run(() => {
-          store
-            .findRecord(
-              BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-              FETCHED_PROJECTION_ID
-            )
-            .then(model => {
-              assert.equal(
-                get(model, 'id'),
-                FETCHED_PROJECTION_ID,
-                'we retrieved the already fetched the model'
-              );
-              assert.equal(findRecordCallCount, 0, 'We did not re-fetch');
-            });
-        });
+      run(() => {
+        store
+          .findRecord(BOOK_EXCERPT_PROJECTION_CLASS_PATH, FETCHED_PROJECTION_ID)
+          .then(model => {
+            assert.equal(
+              get(model, 'id'),
+              FETCHED_PROJECTION_ID,
+              'we retrieved the already fetched the model'
+            );
+            assert.equal(findRecordCallCount, 0, 'We did not re-fetch');
+          });
+      });
 
-        run(() => {
-          store
-            .findRecord(
-              BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-              UNFETCHED_PROJECTION_ID
-            )
-            .then(model => {
-              assert.equal(
-                get(model, 'id'),
-                UNFETCHED_PROJECTION_ID,
-                'we fetched the model'
-              );
-              assert.equal(findRecordCallCount, 1, 'We made a single request');
-            });
-        });
+      run(() => {
+        store
+          .findRecord(
+            BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            UNFETCHED_PROJECTION_ID
+          )
+          .then(model => {
+            assert.equal(
+              get(model, 'id'),
+              UNFETCHED_PROJECTION_ID,
+              'we fetched the model'
+            );
+            assert.equal(findRecordCallCount, 1, 'We made a single request');
+          });
+      });
 
-        /*
+      /*
         Setup findRecord params for base-record requests,
 
         remember:
           the FETCHED_PROJECTION_ID is the unfetched base-record
           the UNFETCHED_PROJECTION_ID is the already fetched base-record
       */
-        findRecordCallCount = 0;
-        expectedFindRecordModelName = NORM_BOOK_CLASS_PATH;
-        trueFindRecordModelName = BOOK_CLASS_PATH;
-        expectedFindRecordId = FETCHED_PROJECTION_ID;
+      findRecordCallCount = 0;
+      expectedFindRecordModelName = NORM_BOOK_CLASS_PATH;
+      trueFindRecordModelName = BOOK_CLASS_PATH;
+      expectedFindRecordId = FETCHED_PROJECTION_ID;
 
-        run(() => {
-          store
-            .findRecord(BOOK_CLASS_PATH, UNFETCHED_PROJECTION_ID)
-            .then(model => {
-              assert.equal(
-                get(model, 'id'),
-                UNFETCHED_PROJECTION_ID,
-                'we retrieved the already fetched the model'
-              );
-              assert.equal(findRecordCallCount, 0, 'We did not re-fetch');
-            });
+      run(() => {
+        store
+          .findRecord(BOOK_CLASS_PATH, UNFETCHED_PROJECTION_ID)
+          .then(model => {
+            assert.equal(
+              get(model, 'id'),
+              UNFETCHED_PROJECTION_ID,
+              'we retrieved the already fetched the model'
+            );
+            assert.equal(findRecordCallCount, 0, 'We did not re-fetch');
+          });
+      });
+
+      run(() => {
+        store.findRecord(BOOK_CLASS_PATH, FETCHED_PROJECTION_ID).then(model => {
+          assert.equal(
+            get(model, 'id'),
+            FETCHED_PROJECTION_ID,
+            'we fetched the model'
+          );
+          assert.equal(findRecordCallCount, 1, 'We made a single request');
         });
+      });
+    });
 
-        run(() => {
-          store
-            .findRecord(BOOK_CLASS_PATH, FETCHED_PROJECTION_ID)
-            .then(model => {
-              assert.equal(
-                get(model, 'id'),
-                FETCHED_PROJECTION_ID,
-                'we fetched the model'
-              );
-              assert.equal(findRecordCallCount, 1, 'We made a single request');
-            });
-        });
-      }
-    );
-
-    skip(`store.peekAll() will not return partial records`, function(assert) {
+    test(`store.peekAll() will not return partial records`, function(assert) {
       let { store } = this;
 
       run(() => {
@@ -459,9 +450,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip('Projections proxy whitelisted attributes to a base-record', function(
-      assert
-    ) {
+    test('Projections proxy whitelisted attributes to a base-record', function(assert) {
       let { store } = this;
       const BOOK_ID = 'isbn:9780439708181';
       const BOOK_TITLE = 'Adventures in Wonderland';


### PR DESCRIPTION
The changes are somewhat disconnected, here is an overview:
- `preloadData` monkey patch to enable us to put a base record data without marking as loaded
- Linking a projection model data to a base model data (no support for save yet)
- Some small changes here and there like relying on `setAttr` instead of assigning directly
- Unskipping relevant tests, which are now passing against Igor's Ember Data branch