### PR TITLE
[Projection Support] Support for saving a projection [1]

### DIFF
--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -325,7 +325,6 @@ export default class M3ModelData {
   }
 
   _inverseMergeUpdates(updates) {
-    // TODO Add more tests for this case
     // TODO Add support for nested objects
     if (!updates) {
       return;

--- a/tests/unit/model-data-test.js
+++ b/tests/unit/model-data-test.js
@@ -25,6 +25,10 @@ module('unit/model-data', function(hooks) {
         this.disconnectedModelDatas[key] = this.modelDatas[key];
         delete this.modelDatas[key];
       },
+
+      isRecordInUse() {
+        return false;
+      },
     });
 
     this.mockInternalModel = (modelName, id) => ({
@@ -196,6 +200,25 @@ module('unit/model-data', function(hooks) {
       baseModelData._projections,
       [baseModelData, projectedModelData],
       'Expected projected model data to be in the projections list'
+    );
+  });
+
+  test('projection model data unregister from base model data and the store on unloadRecord', function(assert) {
+    let projectionModelData = this.storeWrapper.modelDataFor('com.bookstore.projected-book', '1');
+    let baseModelData = this.storeWrapper.modelDataFor('com.bookstore.book', '1');
+
+    // unload the model data
+    projectionModelData.unloadRecord();
+
+    assert.notEqual(
+      this.storeWrapper.disconnectedModelDatas[modelDataKey(projectionModelData)],
+      null,
+      'Expected projection model data to have been disconnected from the store'
+    );
+    assert.equal(
+      baseModelData._projections.find(x => x === projectionModelData),
+      null,
+      'Expected projected model data to have been removed from the projections'
     );
   });
 });

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2015,7 +2015,7 @@ module('unit/projection', function(hooks) {
       assert.equal(get(projectedExcerpt, 'title'), BOOK_TITLE);
     });
 
-    skip(`Unloading the base-record does not unload the projection`, function(assert) {
+    test(`Unloading the base-record does not unload the projection`, function(assert) {
       let { baseRecord, projectedPreview } = this.records;
 
       run(() => {

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2330,7 +2330,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip('newly created and saved projections can receive updates', function(assert) {
+    test('newly created and saved projections can receive updates', function(assert) {
       this.owner.register(
         'adapter:-ember-m3',
         Ember.Object.extend({


### PR DESCRIPTION
Although earlier PR #61 already enabled some tests related to saving,  they just happen to pass, because the default Ember Data behavior for saving works OK. However, it is not correct.

The challenge is to detect when a projection have been _created_ on the server and correctly convert the projection's ModelData to refer to the base model. Because we don't have the ID of the entity in the beginning, we cannot do this setup when the projection is first created.

The detection is done through the `setId()` function, which is called when the server sends the ID of the record. When this function is called, we need to throw away the data and link the projection ModelData to the base ModelData, which should exist by this point (because we have an ID now). 

However, we don't know how much data the server has returned back - it may have returned all the data or it may have returned just ID. To ensure we don't lose data, we need to copy any data, owned by the projection, to the base ModelData. We assume the server knows better what is the current state, therefore any pre-existing base ModelData is considered the source of truth and not overridden.

The PR also handles unloading of the base record correctly, e.g. the base record is not unloaded. However, there is no an existing hook, which can help us with this, so the code assumes additional changes to Ember Data.

Here is the list of changes required in Ember Data for this change:
- `InternalModel.setId` calls `ModelData.setId`
- `InternalModel.unloadRecord` should consult `ModelData.shouldDestroy()` before proceeding to schedule a destruction of the InternalModel.
- `InternalModel.destroy()` calls `ModelData.destroy()` as well. There is an existing `resetRecord()`, which is called when the associated record is dematerialized, but it is also called at other times and there is no guarantee that after calling `resetRecord`, the modelData will not be used again. 

@igorT @hjdivad The above functions will extend the API surface of ModelData and I will appreciate a closer look. These are the easiest things, which worked for the cases, but I'm open to more refined API changes.