### PR TITLE
[Projection Support] Improve handling of nested models [2]

### DIFF
--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -75,7 +75,6 @@ export default class M3ModelData {
     } else {
       this.baseModelName = this._schema.computeBaseModelName(this.modelName);
       if (this.baseModelName && this.id) {
-        // TODO we may not have ID yet?
         this._initBaseModelData(this.baseModelName, id);
       } else {
         this.baseModelData = null;
@@ -207,27 +206,28 @@ export default class M3ModelData {
    */
   getOrCreateNestedModelData(key, modelName, id, internalModel) {
     let nestedModelData = this._nestedModelDatas[key];
-    if (!nestedModelData) {
-      let baseNestedModelData;
-      if (this.baseModelData) {
-        // we have a base, ask it for a nested model data
-        let baseNestedModelName = this._schema.computeBaseModelName(modelName);
-        // TODO We don't have any associated internal model though, because Ember Data is not tracking these, we may have
-        // to fill in the internal model when it is available
-        baseNestedModelData = this.baseModelData.getOrCreateNestedModelData(
-          key,
-          baseNestedModelName,
-          id,
-          null
-        );
-      }
-      nestedModelData = this._nestedModelDatas[key] = this.createNestedModelData(
-        modelName,
+    if (nestedModelData) {
+      return nestedModelData;
+    }
+    let baseNestedModelData;
+    if (this.baseModelData) {
+      // we have a base, ask it for a nested model data
+      let baseNestedModelName = this._schema.computeBaseModelName(modelName);
+      // TODO We don't have any associated internal model though, because Ember Data is not tracking these
+      // we need to fill it in when the nested base model data is requested
+      baseNestedModelData = this.baseModelData.getOrCreateNestedModelData(
+        key,
+        baseNestedModelName,
         id,
-        internalModel,
-        baseNestedModelData
+        null
       );
     }
+    nestedModelData = this._nestedModelDatas[key] = this.createNestedModelData(
+      modelName,
+      id,
+      internalModel,
+      baseNestedModelData
+    );
     return nestedModelData;
   }
 

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -40,6 +40,9 @@ class NestedModelDataWrapper {
   }
 
   notifyPropertyChange(modelName, id, clientId, key) {
+    if (!this.internalModel) {
+      return;
+    }
     assert(
       `Nested model datas can only notify of property changes their associated record. Blocked an attempt to notify ${modelName} with ID ${id} for ${key} property`,
       modelName === this.internalModel.modelName && id === this.internalModel.id
@@ -52,7 +55,7 @@ class NestedModelDataWrapper {
 }
 
 export default class M3ModelData {
-  constructor(modelName, id, clientId, storeWrapper) {
+  constructor(modelName, id, clientId, storeWrapper, baseModelData) {
     this.modelName = modelName;
     this.clientId = clientId;
     this.id = id;
@@ -64,14 +67,19 @@ export default class M3ModelData {
     this.__projections = null;
 
     this._schema = SchemaManager;
-
-    this.baseModelName = this._schema.computeBaseModelName(this.modelName);
-
-    if (this.baseModelName && this.id) {
-      // TODO we may not have ID yet?
-      this._initBaseModelData(this.baseModelName, id);
+    if (baseModelData) {
+      // this is the case of nested model data and we are receiving the base model data directly
+      this.baseModelName = null;
+      this.baseModelData = baseModelData;
+      this.baseModelData._registerProjection(this);
     } else {
-      this.baseModelData = null;
+      this.baseModelName = this._schema.computeBaseModelName(this.modelName);
+      if (this.baseModelName && this.id) {
+        // TODO we may not have ID yet?
+        this._initBaseModelData(this.baseModelName, id);
+      } else {
+        this.baseModelData = null;
+      }
     }
   }
 
@@ -200,10 +208,24 @@ export default class M3ModelData {
   getOrCreateNestedModelData(key, modelName, id, internalModel) {
     let nestedModelData = this._nestedModelDatas[key];
     if (!nestedModelData) {
+      let baseNestedModelData;
+      if (this.baseModelData) {
+        // we have a base, ask it for a nested model data
+        let baseNestedModelName = this._schema.computeBaseModelName(modelName);
+        // TODO We don't have any associated internal model though, because Ember Data is not tracking these, we may have
+        // to fill in the internal model when it is available
+        baseNestedModelData = this.baseModelData.getOrCreateNestedModelData(
+          key,
+          baseNestedModelName,
+          id,
+          null
+        );
+      }
       nestedModelData = this._nestedModelDatas[key] = this.createNestedModelData(
         modelName,
         id,
-        internalModel
+        internalModel,
+        baseNestedModelData
       );
     }
     return nestedModelData;
@@ -218,9 +240,9 @@ export default class M3ModelData {
    * @return {M3ModelData}
    * @private
    */
-  createNestedModelData(modelName, id, internalModel) {
+  createNestedModelData(modelName, id, internalModel, baseModelData) {
     let storeWrapper = new NestedModelDataWrapper(internalModel);
-    return new M3ModelData(modelName, id, null, storeWrapper);
+    return new M3ModelData(modelName, id, null, storeWrapper, baseModelData);
   }
 
   /**

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -75,6 +75,7 @@ export default class M3ModelData {
     } else {
       this.baseModelName = this._schema.computeBaseModelName(this.modelName);
       if (this.baseModelName && this.id) {
+        this.baseModelName = dasherize(this.baseModelName);
         this._initBaseModelData(this.baseModelName, id);
       } else {
         this.baseModelData = null;

--- a/tests/unit/model-data-test.js
+++ b/tests/unit/model-data-test.js
@@ -316,4 +316,26 @@ module('unit/model-data', function(hooks) {
       'Expected complex attribute to have been retained'
     );
   });
+
+  test('nested projection model register in the base model nested model data', function(assert) {
+    let projectionModelData = this.storeWrapper.modelDataFor('com.bookstore.projected-book', '1');
+    let baseModelData = this.storeWrapper.modelDataFor('com.bookstore.book', '1');
+
+    let nestedProjected = projectionModelData.getOrCreateNestedModelData(
+      'preface',
+      'com.bookstore.chapter'
+    );
+
+    assert.strictEqual(
+      baseModelData.hasNestedModelData('preface'),
+      true,
+      'Expected base model data to have created a nested model data'
+    );
+
+    let nestedBase = baseModelData.getOrCreateNestedModelData('preface');
+    assert.ok(
+      nestedBase._projections.find(x => x === nestedProjected),
+      'Expected the nested projection model data to be registered in the nested base model data'
+    );
+  });
 });

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1066,54 +1066,51 @@ module('unit/projection', function(hooks) {
       }
     );
 
-    skip(
-      'Updating an embedded object property on the base-record updates the value for projections',
-      function(assert) {
-        let { store } = this;
-        let { baseRecord, projectedExcerpt } = this.records;
+    test('Updating an embedded object property on the base-record updates the value for projections', function(assert) {
+      let { store } = this;
+      let { baseRecord, projectedExcerpt } = this.records;
 
-        run(() => {
-          store.push({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_CLASS_PATH,
-              attributes: {
-                author: {
-                  location: NEW_AUTHOR_LOCATION,
-                  age: NEW_AUTHOR_AGE,
-                },
+      run(() => {
+        store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {
+              author: {
+                location: NEW_AUTHOR_LOCATION,
+                age: NEW_AUTHOR_AGE,
               },
             },
-          });
+          },
         });
+      });
 
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
 
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
 
-        assert.watchedPropertyCount(
-          baseCounters['author.age'],
-          1,
-          'Afterwards we have dirtied excerpt.author.age'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['author.age'],
-          1,
-          'Afterwards we have dirtied excerpt.author.age'
-        );
-        assert.equal(
-          get(baseRecord, 'author.age'),
-          NEW_AUTHOR_AGE,
-          'base-record has the correct author.age'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'author.age'),
-          NEW_AUTHOR_AGE,
-          'excerpt has the correct author.age'
-        );
-      }
-    );
+      assert.watchedPropertyCount(
+        baseCounters['author.age'],
+        1,
+        'Afterwards we have dirtied excerpt.author.age'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['author.age'],
+        1,
+        'Afterwards we have dirtied excerpt.author.age'
+      );
+      assert.equal(
+        get(baseRecord, 'author.age'),
+        NEW_AUTHOR_AGE,
+        'base-record has the correct author.age'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'author.age'),
+        NEW_AUTHOR_AGE,
+        'excerpt has the correct author.age'
+      );
+    });
 
     skip(
       'Setting an embedded object property on a projection updates the base-record and other projections',
@@ -1197,114 +1194,108 @@ module('unit/projection', function(hooks) {
       }
     );
 
-    skip(
-      'Updating an embedded object property on a projection updates the base-record and other projections',
-      function(assert) {
-        let { store } = this;
-        let { baseRecord, projectedExcerpt } = this.records;
+    test('Updating an embedded object property on a projection updates the base-record and other projections', function(assert) {
+      let { store } = this;
+      let { baseRecord, projectedExcerpt } = this.records;
 
-        run(() => {
-          store.preloadData({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_CLASS_PATH,
-              attributes: {
-                author: {
-                  location: NEW_AUTHOR_LOCATION,
-                  age: NEW_AUTHOR_AGE,
-                },
+      run(() => {
+        store.preloadData({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {
+              author: {
+                location: NEW_AUTHOR_LOCATION,
+                age: NEW_AUTHOR_AGE,
               },
             },
-          });
-          store.push({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
-              attributes: {},
-            },
-          });
+          },
         });
+        store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            attributes: {},
+          },
+        });
+      });
 
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
 
-        assert.watchedPropertyCount(
-          baseCounters['author.age'],
-          1,
-          'Afterwards we have dirtied excerpt.author.age'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['author.age'],
-          1,
-          'Afterwards we have dirtied excerpt.author.age'
-        );
-        assert.equal(
-          get(baseRecord, 'author.age'),
-          NEW_AUTHOR_AGE,
-          'base-record has the correct author.age'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'author.age'),
-          NEW_AUTHOR_AGE,
-          'excerpt has the correct author.age'
-        );
-      }
-    );
+      assert.watchedPropertyCount(
+        baseCounters['author.age'],
+        1,
+        'Afterwards we have dirtied excerpt.author.age'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['author.age'],
+        1,
+        'Afterwards we have dirtied excerpt.author.age'
+      );
+      assert.equal(
+        get(baseRecord, 'author.age'),
+        NEW_AUTHOR_AGE,
+        'base-record has the correct author.age'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'author.age'),
+        NEW_AUTHOR_AGE,
+        'excerpt has the correct author.age'
+      );
+    });
 
-    skip(
-      'Updating an embedded object property on a nested projection updates the base-record and other projections',
-      function(assert) {
-        let { store } = this;
-        let { baseRecord, projectedExcerpt } = this.records;
+    test('Updating an embedded object property on a nested projection updates the base-record and other projections', function(assert) {
+      let { store } = this;
+      let { baseRecord, projectedExcerpt } = this.records;
 
-        run(() => {
-          store.preloadData({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_CLASS_PATH,
-              attributes: {
-                author: {
-                  location: NEW_AUTHOR_LOCATION,
-                },
+      run(() => {
+        store.preloadData({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {
+              author: {
+                location: NEW_AUTHOR_LOCATION,
               },
             },
-          });
-          store.push({
-            data: {
-              id: BOOK_ID,
-              type: BOOK_PREVIEW_PROJECTION_CLASS_PATH,
-              attributes: {},
-            },
-          });
+          },
         });
+        store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+            attributes: {},
+          },
+        });
+      });
 
-        let { baseRecordWatcher, excerptWatcher } = this.watchers;
-        let baseCounters = baseRecordWatcher.counters;
-        let excerptCounters = excerptWatcher.counters;
+      let { baseRecordWatcher, excerptWatcher } = this.watchers;
+      let baseCounters = baseRecordWatcher.counters;
+      let excerptCounters = excerptWatcher.counters;
 
-        assert.watchedPropertyCount(
-          baseCounters['author.age'],
-          0,
-          'Afterwards we have not dirtied excerpt.author.age'
-        );
-        assert.watchedPropertyCount(
-          excerptCounters['author.age'],
-          0,
-          'Afterwards we have not dirtied excerpt.author.age'
-        );
-        assert.equal(
-          get(baseRecord, 'author.age'),
-          AUTHOR_AGE,
-          'base-record has the correct author.age'
-        );
-        assert.equal(
-          get(projectedExcerpt, 'author.age'),
-          AUTHOR_AGE,
-          'excerpt has the correct author.age'
-        );
-      }
-    );
+      assert.watchedPropertyCount(
+        baseCounters['author.age'],
+        0,
+        'Afterwards we have not dirtied excerpt.author.age'
+      );
+      assert.watchedPropertyCount(
+        excerptCounters['author.age'],
+        0,
+        'Afterwards we have not dirtied excerpt.author.age'
+      );
+      assert.equal(
+        get(baseRecord, 'author.age'),
+        AUTHOR_AGE,
+        'base-record has the correct author.age'
+      );
+      assert.equal(
+        get(projectedExcerpt, 'author.age'),
+        AUTHOR_AGE,
+        'excerpt has the correct author.age'
+      );
+    });
   });
 
   module('property notifications on resolved objects', function(hooks) {


### PR DESCRIPTION
The code has been refactored to correctly delegate handling updates to the nested models, but projections of the nested models are not notified of these updates, because there is no link between nested models and the normal mechanism for notifying them of changes to the data does not work.

This PR implements a way to make this work correctly for nested models projections - when a ModelData instance is asked to create a nested ModelData, it requests its own base ModelData to provide a nested ModelData, which serves as a base for the new one. At the end, there will be a structure like this:

```
+--------------+                         +----------------+
|              +                         |                |
|  Projection     ---------------------> |      Base      |
|              |                         |                |
+----------+---+                         +-------------+--+
           |                                           |
           |                                           |
        +--v-------------+                          +--v-------------+
        |                |                          |                |
        |    NestedPrj   +------------------------> |   NestedBase   |
        |                |                          |                |
        +----------+-----+                          +------------+---+
                   |                                             |
                 +-v---------------+                          +--v--------------+
                 |                 |                          |                 |
                 | NestedNestedPrj +------------------------> |NestedNestedBase
                 |                 |                          |                 |
                 +-----------------+                          +-----------------+
```
This entirely expects that all projections of a nested hash will also be presented as nested model, which is reasonable.

I don't think we have alternatives at this point, which would not conflict other decisions we've made. The one I could think of, is to run a common update strategy over the whole `data` hash and then ask each impacted `ModelData` to do its notifications. However, this conflicts with our decision where the existence of a nested model determines whether we want to merge or overwrite updates.

@igorT This is the case, which you wanted to think about. Let me know if you have something better in mind.