### PR TITLE
Allow id mutation in nested models

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -530,4 +530,14 @@ class EmbeddedMegamorphicModel extends MegamorphicModel {
       { id: 'ember-m3.nested-model-unloadRecord' }
     );
   }
+
+  // no special behaviour for ids of embedded/nested models
+
+  get id() {
+    return this.unknownProperty('id');
+  }
+
+  set id(value) {
+    return this.setUnknownProperty('id', value);
+  }
 }


### PR DESCRIPTION
It's a bit strange to do so, but it's not actually an issue as it is for top-level models.