### PR TITLE
passing _data object to schema.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ export function initialize() {
       return BookstoreRegExp.test(modelName);
     },
 
-    computeAttributeReference(key, value) {
+    computeAttributeReference(key, value, modelName, data) {
       if (!value) { return; }
 
       let match;
@@ -86,7 +86,7 @@ export function initialize() {
       }
     },
 
-    computeNestedModel(key, value) {
+    computeNestedModel(key, value, modelName, data) {
       if (value && typeof value === 'object') {
         return {
           id: value.id,
@@ -299,7 +299,7 @@ The `schema` you pass in is an object with the following properties.
   `modelName`.  It's fine to just `return true` here but this hook allows
   `ember-m3` to work alongside `DS.Model`.
 
-- `computeAttributeReference(key, value)`  A function that determines
+- `computeAttributeReference(key, value, modelName, data)`  A function that determines
   whether an attribute is a reference.  If it is not, return `null` or
   `undefined`.
   Otherwise return an object with properties:
@@ -309,13 +309,13 @@ The `schema` you pass in is an object with the following properties.
   Note that attribute references are all treated as synchronous.  There is no
   ember-m3 analogue to `DS.Model` async relationships.
 
--  `isAttributeArrayReference(key, value, modelName)` Whether the attribute
+-  `isAttributeArrayReference(key, value, modelName, data)` Whether the attribute
    should be treated as an array reference.  If `false` array values whose members are
    attribute references will still be resolved as an array of models.  If `true`
    they will be resoled as a `RecordArray` of models; additionally a
    `RecordArray` will be returned even for `null` values.
 
-- `computeNestedModel(key, value, modelName)` Whether `value` should be treated
+- `computeNestedModel(key, value, modelName, data)` Whether `value` should be treated
   as a nested model.  Useful for deeply nested references, eg with the following
   data:
   ```js
@@ -339,7 +339,7 @@ The `schema` you pass in is an object with the following properties.
   treat all objects as nested models (be careful with transforms; you may
   want to explicitly check `value.constructor`).  eg
   ```js
-  computeNestedModel(key, value, modelName) {
+  computeNestedModel(key, value, modelName, data) {
     if(value && value.constructor === Object) {
       return {
         id: value.id,

--- a/addon/model.js
+++ b/addon/model.js
@@ -54,7 +54,12 @@ function resolveValue(key, value, modelName, store, schema, model) {
     return resolvePlainArray(key, value, modelName, store, schema, model);
   }
 
-  let reference = schema.computeAttributeReference(key, value, modelName);
+  let reference = schema.computeAttributeReference(
+    key,
+    value,
+    modelName,
+    model._internalModel._data
+  );
   if (reference) {
     if (reference.type === null) {
       // for schemas with a global id-space but multiple types, schemas may

--- a/addon/schema-manager.js
+++ b/addon/schema-manager.js
@@ -3,8 +3,8 @@ export class SchemaManager {
     this.schema = null;
   }
 
-  computeAttributeReference(key, value, modelname) {
-    return this.schema.computeAttributeReference(key, value, modelname);
+  computeAttributeReference(key, value, modelname, data) {
+    return this.schema.computeAttributeReference(key, value, modelname, data);
   }
 
   isAttributeArrayReference(key, value, modelname) {

--- a/addon/schema-manager.js
+++ b/addon/schema-manager.js
@@ -7,12 +7,12 @@ export class SchemaManager {
     return this.schema.computeAttributeReference(key, value, modelname, data);
   }
 
-  isAttributeArrayReference(key, value, modelname) {
-    return this.schema.isAttributeArrayReference(key, value, modelname);
+  isAttributeArrayReference(key, value, modelname, data) {
+    return this.schema.isAttributeArrayReference(key, value, modelname, data);
   }
 
-  computeNestedModel(key, value, modelname) {
-    return this.schema.computeNestedModel(key, value, modelname);
+  computeNestedModel(key, value, modelname, data) {
+    return this.schema.computeNestedModel(key, value, modelname, data);
   }
 
   includesModel(key, value, modelName) {

--- a/blueprints/schema-initializer/files/app/initializers/schema-initializer.js
+++ b/blueprints/schema-initializer/files/app/initializers/schema-initializer.js
@@ -3,21 +3,21 @@ import SchemaManager from 'ember-m3/schema-manager';
 export function initialize(/* application */) {
   SchemaManager.registerSchema({
 
-    computeAttributeReference(/* key, value, modelName */) {
+    computeAttributeReference(/* key, value, modelName, data */) {
       // If the attribute with value `value` under key `key` of `modelName` is
       // a reference to another model, return `{ type, id }`, otherwise return
       // null.
       return null;
     },
 
-    isAttributeArrayReference(/* key, value, modelName */) {
+    isAttributeArrayReference(/* key, value, modelName, data */) {
       // If the attribute with value `value` under key `key` of `modelName` is
       // an array of references to models (eg a has-many) return `true` and
       // `false` otherwise.
       return false;
     },
 
-    computeNestedModel(/* key, value, modelName */) {
+    computeNestedModel(/* key, value, modelName, data */) {
       // If the attribute with value `value` under key `key` of `modelName`
       // should be treated as a nested model instead of a plain POJO, then
       // return `{ id, type, attributes }`.  Arrays will have this method


### PR DESCRIPTION
passing _data object to schema.js, in order to check the key and value and compute attribute reference.