### PR TITLE
Remove direct dependency on ember-source.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
       "node_modules/.bin/prettier --write --ignore-path .gitignore 'addon/**/*.js' 'app/**/*.js' 'tests/**/*.js'"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.3.0",
-    "ember-source": "^2.16.2"
+    "ember-cli-babel": "^6.3.0"
   },
   "peerDependencies": {
     "ember-data": "~3.1.0"


### PR DESCRIPTION
ember-source should only be a dev dependency here (and possibly a peer dependency also, though I didn't introduce that as I wasn't sure we needed it to be explicit).