### PR TITLE
Fire array change events on content

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
 
 install:
   - yarn install --no-lockfile --non-interactive
-  - yarn list
 
 script:
   # Usually, it's ok to finish the test scenario without reverting

--- a/addon/record-array.js
+++ b/addon/record-array.js
@@ -10,16 +10,12 @@ export default RecordArray.extend({
   replaceContent(idx, removeAmt, newModels) {
     let addAmt = newModels.length;
 
-    this.arrayContentWillChange(idx, removeAmt, addAmt);
-
     let newInternalModels = new Array(addAmt);
     for (let i = 0; i < newInternalModels.length; ++i) {
       newInternalModels[i] = newModels.objectAt(i)._internalModel;
     }
-    this.content.splice(idx, removeAmt, ...newInternalModels);
+    this.content.replace(idx, removeAmt, newInternalModels);
     // TODO: update the backing m3's internalModel._data
-
-    this.arrayContentDidChange(idx, removeAmt, addAmt);
   },
 
   _update() {


### PR DESCRIPTION
Previously we fired array change events on the proxy itself.  This is incompatible with the changes in https://github.com/emberjs/ember.js/pull/16166 which depend on the events firing on the underlying content.