### PR TITLE
clean up some beta issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module',
   },
-  extends: ['eslint:recommended', 'prettier'],
+  extends: ['eslint:recommended', 'prettier', 'plugin:ember/recommended'],
   env: {
     browser: true,
   },

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
 import DS from 'ember-data';
+import DataAdapter from '@ember/debug/data-adapter';
 
 import MegamorphicModel from '../model';
 import M3ModelData from '../model-data';
@@ -8,7 +8,7 @@ import SchemaManager from '../schema-manager';
 import QueryCache from '../query-cache';
 
 extendStore(DS.Store);
-extendDataAdapter(Ember.DataAdapter);
+extendDataAdapter(DataAdapter);
 
 export function extendStore(Store) {
   Store.reopen({

--- a/addon/model.js
+++ b/addon/model.js
@@ -7,7 +7,13 @@ import SchemaManager from './schema-manager';
 import M3RecordArray from './record-array';
 import { OWNER_KEY } from './util';
 
-const { get, set, propertyWillChange, propertyDidChange, computed, A } = Ember;
+const { get, set, propertyDidChange, computed, A } = Ember;
+let { notifyPropertyChange } = Ember;
+
+const HasNotifyPropertyChange = notifyPropertyChange !== undefined;
+if (!HasNotifyPropertyChange) {
+  notifyPropertyChange = propertyDidChange;
+}
 
 const { deleted: { uncommitted: deletedUncommitted }, loaded: { saved: loadedSaved } } = RootState;
 
@@ -366,7 +372,7 @@ export default class MegamorphicModel extends Ember.Object {
 
   deleteRecord() {
     this._internalModel.currentState = deletedUncommitted;
-    propertyDidChange(this, 'currentState');
+    notifyPropertyChange(this, 'currentState');
   }
 
   destroyRecord(options) {
@@ -378,7 +384,7 @@ export default class MegamorphicModel extends Ember.Object {
     let dirtyKeys = this._internalModel._modelData.rollbackAttributes();
     this._internalModel.currentState = loadedSaved;
 
-    propertyDidChange(this, 'currentState');
+    notifyPropertyChange(this, 'currentState');
 
     if (dirtyKeys && dirtyKeys.length > 0) {
       this._notifyProperties(dirtyKeys);
@@ -462,8 +468,6 @@ export default class MegamorphicModel extends Ember.Object {
       );
     }
 
-    propertyWillChange(this, key);
-
     // TODO: need to be able to update relationships
     // TODO: also on set(x) ask schema if this should be a ref (eg if it has an
     // entityUrn)
@@ -485,7 +489,7 @@ export default class MegamorphicModel extends Ember.Object {
       delete this._cache[key];
     }
 
-    propertyDidChange(this, key);
+    notifyPropertyChange(this, key);
   }
 
   _setRecordArray(key, models) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -1,13 +1,20 @@
+// This lint error disables "this.attrs" everywhere.  What could go wrong?
+/* eslint-disable ember/no-attrs-in-components */
+
 import Ember from 'ember';
 import { RootState } from 'ember-data/-private';
 import { dasherize } from '@ember/string';
+import EmberObject, { computed, get, set, defineProperty } from '@ember/object';
+import { A } from '@ember/array';
+import { warn } from '@ember/debug';
+import { alias } from '@ember/object/computed';
 
 import M3ModelData from './model-data';
 import SchemaManager from './schema-manager';
 import M3RecordArray from './record-array';
 import { OWNER_KEY } from './util';
 
-const { get, set, propertyDidChange, computed, A } = Ember;
+const { propertyDidChange } = Ember;
 let { notifyPropertyChange } = Ember;
 
 const HasNotifyPropertyChange = notifyPropertyChange !== undefined;
@@ -151,7 +158,7 @@ function resolveRecordArray(key, value, modelName, store, schema, schemaInterfac
 
   let array = M3RecordArray.create({
     modelName: '-ember-m3',
-    content: Ember.A(),
+    content: A(),
     store: store,
     manager: recordArrayManager,
   });
@@ -224,7 +231,7 @@ const retrieveFromCurrentState = computed('currentState', function(key) {
 //      CP or setknownProperty can rely on any initialization
 let initProperites = Object.create(null);
 
-export default class MegamorphicModel extends Ember.Object {
+export default class MegamorphicModel extends EmberObject {
   init(properties) {
     // Drop Ember.Object subclassing instead
     super.init(...arguments);
@@ -404,11 +411,12 @@ export default class MegamorphicModel extends Ember.Object {
     // TODO IGOR DAVID
     // figure out if any of the below should be moved into model data
     if (rawValue === undefined) {
-      let alias = this._schema.getAttributeAlias(this._modelName, key);
-      if (alias) {
-        const cp = Ember.computed.alias(alias);
+      let attrAlias = this._schema.getAttributeAlias(this._modelName, key);
+      if (attrAlias) {
+        const cp = alias(attrAlias);
         cp.set = disallowAliasSet;
-        this[key] = cp;
+        defineProperty(this, key, cp);
+        // may also be reasonable to fall back to Ember.get after defining the property.
         return cp.get(this, key);
       }
 
@@ -525,21 +533,21 @@ MegamorphicModel.prototype.currentState = null;
 MegamorphicModel.prototype.isError = null;
 MegamorphicModel.prototype.adapterError = null;
 
-MegamorphicModel.relationshipsByName = new Ember.Map();
+MegamorphicModel.relationshipsByName = new Map();
 
 // STATE PROPS
-MegamorphicModel.prototype.isEmpty = retrieveFromCurrentState;
-MegamorphicModel.prototype.isLoading = retrieveFromCurrentState;
-MegamorphicModel.prototype.isLoaded = retrieveFromCurrentState;
-MegamorphicModel.prototype.isSaving = retrieveFromCurrentState;
-MegamorphicModel.prototype.isDeleted = retrieveFromCurrentState;
-MegamorphicModel.prototype.isNew = retrieveFromCurrentState;
-MegamorphicModel.prototype.isValid = retrieveFromCurrentState;
-MegamorphicModel.prototype.dirtyType = retrieveFromCurrentState;
+defineProperty(MegamorphicModel.prototype, 'isEmpty', retrieveFromCurrentState);
+defineProperty(MegamorphicModel.prototype, 'isLoading', retrieveFromCurrentState);
+defineProperty(MegamorphicModel.prototype, 'isLoaded', retrieveFromCurrentState);
+defineProperty(MegamorphicModel.prototype, 'isSaving', retrieveFromCurrentState);
+defineProperty(MegamorphicModel.prototype, 'isDeleted', retrieveFromCurrentState);
+defineProperty(MegamorphicModel.prototype, 'isNew', retrieveFromCurrentState);
+defineProperty(MegamorphicModel.prototype, 'isValid', retrieveFromCurrentState);
+defineProperty(MegamorphicModel.prototype, 'dirtyType', retrieveFromCurrentState);
 
 class EmbeddedMegamorphicModel extends MegamorphicModel {
   unloadRecord() {
-    Ember.warn(
+    warn(
       `Nested models cannot be directly unloaded.  Perhaps you meant to unload the top level model, '${
         this._topModel._modelName
       }:${this._topModel.id}'`,

--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
-
-const { get, RSVP: { resolve } } = Ember;
+import { get } from '@ember/object';
+import { A } from '@ember/array';
+import { resolve } from 'rsvp';
 
 import MegamorphicModel from './model';
 import M3RecordArray from './record-array';
@@ -185,7 +185,7 @@ export default class QueryCache {
   _createRecordArray(internalModels, query) {
     let array = M3RecordArray.create({
       modelName: '-ember-m3',
-      content: Ember.A(),
+      content: A(),
       store: this._store,
       manager: this._recordArrayManager,
 

--- a/addon/util.js
+++ b/addon/util.js
@@ -1,6 +1,4 @@
-import Ember from 'ember';
-
-const { setOwner } = Ember;
+import { setOwner } from '@ember/application';
 
 export function setDiff(a, b) {
   let result = [];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "ember-m3",
   "version": "0.4.0",
   "description": "The default blueprint for ember-cli addons.",
-  "keywords": ["ember-addon"],
+  "keywords": [
+    "ember-addon"
+  ],
   "license": "MIT",
   "author": "",
   "directories": {
@@ -14,8 +16,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "ember try:each",
-    "format":
-      "node_modules/.bin/prettier --write --ignore-path .gitignore 'addon/**/*.js' 'app/**/*.js' 'tests/**/*.js'"
+    "format": "node_modules/.bin/prettier --write --ignore-path .gitignore 'addon/**/*.js' 'app/**/*.js' 'tests/**/*.js'"
   },
   "files": [
     "package.json",
@@ -59,6 +60,7 @@
     "ember-source": "~3.0.0",
     "ember-welcome-page": "^3.0.0",
     "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-ember": "^5.0.3",
     "eslint-plugin-prettier": "^2.3.1",
     "loader.js": "^4.2.3",
     "pretender": "^1.4.2",

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver,

--- a/tests/dummy/app/helpers/month-of.js
+++ b/tests/dummy/app/helpers/month-of.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import { helper } from '@ember/component/helper';
 
 export function monthOf(params /*, hash*/) {
   let [date] = params;
   return date && date.getMonth() + 1;
 }
 
-export default Ember.Helper.helper(monthOf);
+export default helper(monthOf);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL,
 });

--- a/tests/dummy/app/routes/alt.js
+++ b/tests/dummy/app/routes/alt.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     return this.store.queryURL('/api1.json');
   },

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   init(...args) {
     this._super(...args);
     this.invocation = 0;

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
+import { resolve } from 'rsvp';
 import { module } from 'qunit';
-import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { resolve } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,12 +1,13 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
+import { merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
-  return Ember.run(() => {
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/unit/initializers/m3-store-test.js
+++ b/tests/unit/initializers/m3-store-test.js
@@ -1,8 +1,8 @@
+import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
-import { zip } from 'lodash';
 
-import Ember from 'ember';
+import { zip } from 'lodash';
 
 import MegamorphicModelFactory from 'ember-m3/factory';
 import SchemaManager from 'ember-m3/schema-manager';
@@ -26,10 +26,15 @@ module('unit/initializers/m3-store', {
       models: {},
     });
 
-    let MockStore = Ember.Object.extend({
-      adapterFor: (this.adapterForStub = this.sinon.stub()),
-      serializerFor: (this.serializerForStub = this.sinon.stub()),
-      modelFactoryFor: (this.modelFactoryForStub = this.sinon.stub()),
+    // this indirection is to work around false positives in
+    // ember/avoid-leaking-state-in-ember-objects
+    this.adapterForStub = this.sinon.stub();
+    this.serializerForStub = this.sinon.stub();
+    this.modelFactoryForStub = this.sinon.stub();
+    let MockStore = EmberObject.extend({
+      adapterFor: this.adapterForStub,
+      serializerFor: this.serializerForStub,
+      modelFactoryFor: this.modelFactoryForStub,
     });
     MockStore.toString = () => 'MockStore';
     extendStore(MockStore);

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -2159,7 +2159,7 @@ module('unit/model', function(hooks) {
       false,
       'nested record do not appear in identity map'
     );
-    let warnSpy = this.sinon.spy(Ember, 'warn');
+    let warnSpy = this.sinon.stub(Ember, 'warn');
     nestedModel.unloadRecord();
     assert.deepEqual(zip(warnSpy.thisValues.map(x => x + ''), warnSpy.args), [
       [

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -723,8 +723,20 @@ module('unit/model', function(hooks) {
       sept1989,
       'alias to value present with transform'
     );
+    assert.equal(
+      get(model, 'title'),
+      `Harry Potter and the Sorcerer's Stone`,
+      'alias to value present after caching'
+    );
     assert.equal(get(model, 'cost'), undefined, 'alias to missing');
     assert.equal(get(model, 'hb'), true, 'alias to missing with default');
+
+    set(model, 'name', 'Harry Potter and the different title');
+    assert.equal(
+      get(model, 'title'),
+      `Harry Potter and the different title`,
+      'alias invalidated when dependent is changed'
+    );
   });
 
   test('schema can access other attributes when computing attribute references', function(assert) {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -2003,7 +2003,7 @@ module('unit/model', function(hooks) {
 
           return Promise.resolve({
             data: {
-              id: 1,
+              id: '1',
               type: 'com.example.bookstore.Book',
               attributes: {
                 name: 'The Winds of Winter',
@@ -2017,7 +2017,7 @@ module('unit/model', function(hooks) {
     let model = run(() => {
       return this.store.push({
         data: {
-          id: 1,
+          id: '1',
           type: 'com.example.bookstore.book',
           attributes: {
             name: 'The Winds of Winter',

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1,16 +1,17 @@
+import Ember from 'ember';
 import { module, test, skip } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 
 import DS from 'ember-data';
-import Ember from 'ember';
 import { zip } from 'lodash';
 
 import MegamorphicModel from 'ember-m3/model';
 import SchemaManager from 'ember-m3/schema-manager';
 import { initialize as initializeStore } from 'ember-m3/initializers/m3-store';
-
-const { get, set, run, RSVP: { Promise } } = Ember;
+import EmberObject, { get, set } from '@ember/object';
+import { Promise } from 'rsvp';
+import { run } from '@ember/runloop';
 
 const UrnWithTypeRegex = /^urn:([a-zA-Z.]+):(.*)/;
 const UrnWithoutTypeRegex = /^urn:(.*)/;
@@ -1888,7 +1889,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'serializer:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         serialize(snapshot, options) {
           assert.deepEqual(options, { some: 'options' }, 'options are passed through to serialize');
           assert.equal(snapshot.attr('name'), 'The Winds of Winter', 'attr - name');
@@ -1931,7 +1932,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         updateRecord(store, type, snapshot) {
           assert.equal(snapshot.record.get('isSaving'), true, 'record is saving');
           return Promise.resolve({
@@ -1985,7 +1986,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         findRecord(store, type, id, snapshot) {
           // TODO: this is annoying but name normalization means we get the wrong
           // model name in snapshots. See #11
@@ -2034,7 +2035,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         deteRecord() {
           assert.ok(false, 'Did not make it to adapter');
         },
@@ -2063,7 +2064,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         deleteRecord(store, type, snapshot) {
           assert.equal(snapshot.record.get('isDeleted'), true, 'model is deleted');
           return Promise.resolve();
@@ -2159,6 +2160,14 @@ module('unit/model', function(hooks) {
       false,
       'nested record do not appear in identity map'
     );
+
+    // This is how to assert via workmanw/ember-qunit-assert-helpers but this
+    // helper does not prevent the warning from hitting the console
+    //
+    // assert.expectNoWarning();
+    // nestedModel.unloadRecord();
+    // assert.expectWarning(`Nested models cannot be directly unloaded.  Perhaps you meant to unload the top level model, 'com.example.bookstore.book:1'`);
+
     let warnSpy = this.sinon.stub(Ember, 'warn');
     nestedModel.unloadRecord();
     assert.deepEqual(zip(warnSpy.thisValues.map(x => x + ''), warnSpy.args), [
@@ -2403,7 +2412,7 @@ module('unit/model', function(hooks) {
   test('.rollbackAttributes rolls back nested dirty attributes after a rejected save', function(assert) {
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         updateRecord() {
           return Promise.reject();
         },
@@ -2452,7 +2461,7 @@ module('unit/model', function(hooks) {
   test('updates from .save do not overwrite attributes  or nested attributes set after .save is called', function(assert) {
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         updateRecord() {
           return Promise.resolve({
             data: {
@@ -2549,7 +2558,7 @@ module('unit/model', function(hooks) {
   test('updates from .save clear changed attributes in nested models within arrays', function(assert) {
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         updateRecord() {
           return Promise.resolve({
             data: {
@@ -2626,7 +2635,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         findRecord(store, modelClass, id, snapshot) {
           // TODO: this is annoying but name normalization means we get the wrong
           // model name in snapshots.  Should fix this upstream by dropping name
@@ -2686,7 +2695,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         shouldReloadAll() {
           return true;
         },
@@ -2744,7 +2753,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         shouldReloadAll() {
           return true;
         },
@@ -2803,7 +2812,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         shouldReloadAll() {
           return true;
         },
@@ -2860,7 +2869,7 @@ module('unit/model', function(hooks) {
 
     this.owner.register(
       'adapter:-ember-m3',
-      Ember.Object.extend({
+      EmberObject.extend({
         findRecord(store, modelClass, id, snapshot) {
           assert.equal(snapshot.modelName, 'com.example.bookstore.book', 'snapshot.modelName');
           assert.equal(modelClass, MegamorphicModel);

--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -1,16 +1,17 @@
+import EmberObject from '@ember/object';
+import { Promise, defer, resolve } from 'rsvp';
+import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
 import { zip } from 'lodash';
 
-import Ember from 'ember';
 import DS from 'ember-data';
 
 import { initialize as initializeStore } from 'ember-m3/initializers/m3-store';
 import SchemaManager from 'ember-m3/schema-manager';
 import MegamorphicModel from 'ember-m3/model';
 
-const { RSVP: { resolve, defer, Promise }, run } = Ember;
 const { Serializer } = DS;
 
 function stubCalls(stub) {
@@ -210,7 +211,7 @@ module('unit/query-cache', function(hooks) {
         type: 'my-type',
       },
     };
-    let customAdapter = Ember.Object.create({
+    let customAdapter = EmberObject.create({
       ajax: this.sinon.stub().returns(resolve(payload)),
       defaultSerializer: '-default',
       toString: () => 'my-adapter',

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { A } from '@ember/array';
+import { run } from '@ember/runloop';
 import DS from 'ember-data';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
@@ -6,8 +7,6 @@ import sinon from 'sinon';
 
 import SchemaManager from 'ember-m3/schema-manager';
 import { initialize as initializeStore } from 'ember-m3/initializers/m3-store';
-
-const { A, run } = Ember;
 
 module('unit/store', function(hooks) {
   setupTest(hooks);


### PR DESCRIPTION
This deals with deprecations, but it doesn't handle the failures which stem from the state CPs not being treated as descriptors during dependent notifications stemming from `currentState` change events (thanks for digging into this @dnachev).

Not yet clear whether or not those errors require changing the way the CPs are defined or if this is a regression in ES5_GETTERS.