### PR TITLE
Correctly notifying all projections on `set`

### DIFF
--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -286,6 +286,10 @@ export default class M3ModelData {
       // Add the new value to the changed attributes hash
       this._attributes[key] = value;
     }
+
+    if (!this._notifyProjectionProperties([key])) {
+      this._notifyRecordProperties([key]);
+    }
   }
 
   getAttr(key) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -506,8 +506,6 @@ export default class MegamorphicModel extends EmberObject {
       this._internalModel._modelData.setAttr(key, value);
       delete this._cache[key];
     }
-
-    notifyPropertyChange(this, key);
   }
 
   _setRecordArray(key, models) {

--- a/tests/unit/model-data-test.js
+++ b/tests/unit/model-data-test.js
@@ -28,6 +28,8 @@ module('unit/model-data', function(hooks) {
         this.disconnectedModelDatas[key] = this.modelDatas[key];
         delete this.modelDatas[key];
       },
+
+      notifyPropertyChange() {},
     });
 
     this.mockModelData = function() {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -580,7 +580,9 @@ module('unit/model', function(hooks) {
       'isbn:9780439064873'
     );
     let gobletOfFire = this.store.peekRecord('com.example.bookstore.Book', 'isbn:9780439139601');
-    model.set('otherBooksInSeries', [chamberOfSecrets, gobletOfFire]);
+    run(() => {
+      model.set('otherBooksInSeries', [chamberOfSecrets, gobletOfFire]);
+    });
     assert.deepEqual(
       get(model, 'otherBooksInSeries').mapBy('id'),
       ['isbn:9780439064873', 'isbn:9780439139601'],
@@ -792,7 +794,10 @@ module('unit/model', function(hooks) {
     assert.equal(get(model, 'cost'), undefined, 'alias to missing');
     assert.equal(get(model, 'hb'), true, 'alias to missing with default');
 
-    set(model, 'name', 'Harry Potter and the different title');
+    run(() => {
+      set(model, 'name', 'Harry Potter and the different title');
+    });
+
     assert.equal(
       get(model, 'title'),
       `Harry Potter and the different title`,
@@ -888,9 +893,12 @@ module('unit/model', function(hooks) {
       'attr array ref is array-like'
     );
 
-    set(model, 'otherBooksInSeries', [
-      this.store.peekRecord('com.example.bookstore.Book', 'isbn:9780439064873'),
-    ]);
+    run(() => {
+      set(model, 'otherBooksInSeries', [
+        this.store.peekRecord('com.example.bookstore.Book', 'isbn:9780439064873'),
+      ]);
+    });
+
     // This is part of the special sauce of record arrays
     assert.deepEqual(
       otherBooks.map(b => get(b, 'name')),
@@ -1131,7 +1139,9 @@ module('unit/model', function(hooks) {
     assert.equal(get(model, 'title'), 'The Birth of Britain', 'initial - alias');
     assert.equal(get(model, 'name'), 'The Birth of Britain', 'initial - prop');
 
-    set(model, 'name', 'Vol. I');
+    run(() => {
+      set(model, 'name', 'Vol. I');
+    });
 
     assert.equal(get(model, 'title'), 'Vol. I', 'set prop - cached alias');
     assert.equal(get(model, 'name'), 'Vol. I', 'set prop - prop');
@@ -1160,24 +1170,31 @@ module('unit/model', function(hooks) {
     });
 
     let propChanges = [];
+    // TODO Convert this to use watch-property helper
     model.addObserver('fans', (model, key) => {
       propChanges.push([model + '', key]);
     });
 
     // observe alias
+    // TODO Convert this to use watch-property helper
     model.addObserver('title', (model, key) => {
       propChanges.push([model + '', key]);
     });
 
-    set(model, 'fans', 'millions');
-    // check that alias doesn't get prop changes when not requested
-    set(model, 'name', 'First Book');
+    run(() => {
+      set(model, 'fans', 'millions');
+      // check that alias doesn't get prop changes when not requested
+      set(model, 'name', 'First Book');
+    });
 
     assert.deepEqual(propChanges, [[model + '', 'fans']], 'change events trigger for direct props');
 
     propChanges.splice(0, propChanges.length);
     assert.equal(get(model, 'title'), `First Book`, 'initialize alias');
-    set(model, 'name', 'Book 1');
+
+    run(() => {
+      set(model, 'name', 'Book 1');
+    });
 
     assert.deepEqual(propChanges, [[model + '', 'title']], 'change events trigger for aliases');
   });
@@ -2309,7 +2326,9 @@ module('unit/model', function(hooks) {
       });
     });
 
-    set(model, 'newAttr', 'newAttrValue');
+    run(() => {
+      set(model, 'newAttr', 'newAttrValue');
+    });
 
     return model.serialize({ some: 'options' });
   });
@@ -2350,10 +2369,11 @@ module('unit/model', function(hooks) {
     });
 
     assert.equal(model.get('isSaving'), false, 'initially model not saving');
-    model.set('estimatedPubDate', '2231?');
 
-    return run(() =>
-      model.save().then(() => {
+    return run(() => {
+      model.set('estimatedPubDate', '2231?');
+
+      return model.save().then(() => {
         assert.equal(model.get('isSaving'), false, 'model done saving');
         assert.deepEqual(
           model._internalModel._modelData._data,
@@ -2364,8 +2384,8 @@ module('unit/model', function(hooks) {
           },
           'data post save resolve'
         );
-      })
-    );
+      });
+    });
   });
 
   test('.reload calls findRecord with reload: true and passes adapterOptions', function(assert) {
@@ -2590,9 +2610,11 @@ module('unit/model', function(hooks) {
       });
     });
 
-    model.set('name', 'Alice in Wonderland');
-    model.set('rating', null);
-    model.set('expectedPubDate', undefined);
+    run(() => {
+      model.set('name', 'Alice in Wonderland');
+      model.set('rating', null);
+      model.set('expectedPubDate', undefined);
+    });
 
     assert.deepEqual(
       model.changedAttributes(),
@@ -2635,8 +2657,10 @@ module('unit/model', function(hooks) {
 
     assert.deepEqual(model.changedAttributes(), {}, 'initially no attributes are changed');
 
-    set(model, 'name', 'secret book name');
-    set(model, 'newAttr', 'a wild attribute appears!');
+    run(() => {
+      set(model, 'name', 'secret book name');
+      set(model, 'newAttr', 'a wild attribute appears!');
+    });
 
     assert.deepEqual(
       model.changedAttributes(),
@@ -2647,11 +2671,13 @@ module('unit/model', function(hooks) {
       'initially no attributes are changed'
     );
 
-    set(nested, 'name', 'a new chapter name');
-    set(nested, 'newAttr', 'first chapter; new attr!');
-    set(doubleNested, 'number', 24601);
-    set(doubleNested, 'anotherNewAttr', 'another new attr!');
-    set(model, 'authorNotes', { text: 'this book will definitely sell well' });
+    run(() => {
+      set(nested, 'name', 'a new chapter name');
+      set(nested, 'newAttr', 'first chapter; new attr!');
+      set(doubleNested, 'number', 24601);
+      set(doubleNested, 'anotherNewAttr', 'another new attr!');
+      set(model, 'authorNotes', { text: 'this book will definitely sell well' });
+    });
 
     assert.deepEqual(
       model.changedAttributes(),
@@ -2690,7 +2716,9 @@ module('unit/model', function(hooks) {
       });
     });
 
-    set(model, 'chapters', ['so windy', 'winter winter']);
+    run(() => {
+      set(model, 'chapters', ['so windy', 'winter winter']);
+    });
 
     assert.deepEqual(
       model.changedAttributes(),
@@ -2759,8 +2787,10 @@ module('unit/model', function(hooks) {
       });
     });
 
-    model.set('name', 'Some other book');
-    model.rollbackAttributes();
+    run(() => {
+      model.set('name', 'Some other book');
+      model.rollbackAttributes();
+    });
 
     assert.equal(
       get(model, 'currentState.stateName'),
@@ -2787,11 +2817,13 @@ module('unit/model', function(hooks) {
       });
     });
 
-    model.set('name', 'Some other book');
-    // cache new value in resolution cache
-    assert.equal(get(model, 'name'), 'Some other book', 'value is set correctly (and cached)');
+    run(() => {
+      model.set('name', 'Some other book');
+      // cache new value in resolution cache
+      assert.equal(get(model, 'name'), 'Some other book', 'value is set correctly (and cached)');
 
-    model.rollbackAttributes();
+      model.rollbackAttributes();
+    });
 
     assert.equal(
       get(model, 'currentState.stateName'),
@@ -2937,9 +2969,11 @@ module('unit/model', function(hooks) {
     let nestedModel = get(model, 'nextChapter');
     let doubleNested = get(model, 'nextChapter.nextChapter');
 
-    set(model, 'name', 'Alice in Wonderland');
-    set(nestedModel, 'name', 'There must be some first chapter');
-    set(doubleNested, 'name', 'Likely there is a second chapter as well');
+    run(() => {
+      set(model, 'name', 'Alice in Wonderland');
+      set(nestedModel, 'name', 'There must be some first chapter');
+      set(doubleNested, 'name', 'Likely there is a second chapter as well');
+    });
 
     return run(() => {
       let savePromise = model.save();

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -625,7 +625,7 @@ module('unit/projection', function(hooks) {
       this.records = null;
     });
 
-    skip('Setting on the base-record updates projections', function(assert) {
+    test('Setting on the base-record updates projections', function(assert) {
       let { baseRecord } = this.records;
 
       run(() => {
@@ -676,7 +676,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip('Setting a projection updates the base-record and other projections', function(assert) {
+    test('Setting a projection updates the base-record and other projections', function(assert) {
       let preview = this.records.projectedPreview;
       let baseRecord = this.records.baseRecord;
 
@@ -1433,7 +1433,7 @@ module('unit/projection', function(hooks) {
       this.records = null;
     });
 
-    skip('Setting a resolution property via the base-record updates projections and nested projections', function(assert) {
+    test('Setting a resolution property via the base-record updates projections and nested projections', function(assert) {
       let { baseRecord, projectedExcerpt } = this.records;
 
       run(() => {
@@ -1519,7 +1519,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip('Setting a resolution property via a projection updates the base-record, other projections and nested projections', function(assert) {
+    test('Setting a resolution property via a projection updates the base-record, other projections and nested projections', function(assert) {
       let { baseRecord, projectedExcerpt } = this.records;
 
       run(() => {
@@ -1554,7 +1554,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip('Setting a resolution property via a nested projection updates the base-record and other projections', function(assert) {
+    test('Setting a resolution property via a nested projection updates the base-record and other projections', function(assert) {
       let { baseRecord, projectedExcerpt, projectedPreview } = this.records;
 
       run(() => {

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -685,15 +685,15 @@ module('unit/projection', function(hooks) {
         set(preview, 'title', NEW_TITLE);
       });
 
-      assert.throws(
-        () => {
-          run(() => {
+      run(() => {
+        assert.throws(
+          () => {
             set(preview, 'description', NEW_DESCRIPTION);
-          });
-        },
-        /whitelist/gi,
-        'Setting a non-whitelisted property throws an error'
-      );
+          },
+          /whitelist/gi,
+          'Setting a non-whitelisted property throws an error'
+        );
+      });
       assert.equal(
         this.watchers.baseRecordWatcher.counts.description,
         0,
@@ -1063,15 +1063,15 @@ module('unit/projection', function(hooks) {
         set(projectedPreview, 'author.location', NEW_AUTHOR_LOCATION);
       });
 
-      assert.throws(
-        () => {
-          run(() => {
+      run(() => {
+        assert.throws(
+          () => {
             set(projectedPreview, 'author.age', NEW_AUTHOR_AGE);
-          });
-        },
-        /whitelist/gi,
-        'Setting a non-whitelisted property on a projection over an embedded object throws an error'
-      );
+          },
+          /whitelist/gi,
+          'Setting a non-whitelisted property on a projection over an embedded object throws an error'
+        );
+      });
 
       let { baseRecordWatcher, excerptWatcher } = this.watchers;
       let baseCounts = baseRecordWatcher.counts;
@@ -1561,15 +1561,15 @@ module('unit/projection', function(hooks) {
         set(projectedPreview, 'publisher.location', NEW_PUBLISHER_LOCATION);
       });
 
-      assert.throws(
-        () => {
-          run(() => {
+      run(() => {
+        assert.throws(
+          () => {
             set(projectedPreview, 'publisher.owner', NEW_PUBLISHER_OWNER);
-          });
-        },
-        /whitelist/gi,
-        'Setting a non-whitelisted property on a projection over a resolved record throws an error'
-      );
+          },
+          /whitelist/gi,
+          'Setting a non-whitelisted property on a projection over a resolved record throws an error'
+        );
+      });
 
       let { baseRecordWatcher, excerptWatcher } = this.watchers;
 


### PR DESCRIPTION
When we `set` on a projection, we delegate to the base always, but the change event was not propagated to all projections.

This PR adds this (essentially moving the `notifyPropertyChange()` call to the `setAttr()`). It has the side effect, because it will use the `storeWrapper.notifyPropertyChange()` call, which requires to be run in a runloop causing many of the existing tests to be changed slightly.