### PR TITLE
[BUGFIX] Ensure `notifyProperties` does not get called with undefined

### DIFF
--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -318,7 +318,7 @@ export default class M3ModelData {
       }
     }
 
-    if (notifyRecord) {
+    if (dirtyKeys && dirtyKeys.length && notifyRecord) {
       this._embeddedInternalModel.record._notifyProperties(dirtyKeys);
     }
 

--- a/tests/unit/model-data-test.js
+++ b/tests/unit/model-data-test.js
@@ -123,6 +123,23 @@ module('unit/model-data', function(hooks) {
     );
   });
 
+  test('.rollbackAttributes does not call notifyPropertyChange with undefined without hasChangedAttributes', function(assert) {
+    assert.expect(1);
+    const rollbackAttributesSpy = this.sinon.spy();
+    let modelData = new M3ModelData(
+      'com.exmaple.bookstore.book',
+      '1',
+      null,
+      this.storeWrapper,
+      null,
+      null,
+      null,
+      { record: { _notifyProperties: rollbackAttributesSpy } }
+    );
+    modelData.rollbackAttributes(true);
+    assert.equal(rollbackAttributesSpy.getCalls().length, 0, 'rollbackAttributes was not called');
+  });
+
   module('with nested models', function(hooks) {
     hooks.beforeEach(function() {
       this.topModelData = new M3ModelData(


### PR DESCRIPTION
Since `dirtyKeys` is initialized as `undefined`, we want to guard against calling `_notifyProperties` with `undefined`.
