### PR TITLE
Projections unload and save 

### DIFF
--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -495,16 +495,16 @@ export default class M3ModelData {
   }
 
   _initBaseModelDataOnCommit(modelName, id) {
-    // TODO Recursively init any existing nested model datas as well
     let projectionData = this._data;
+    // TODO Recursively init any existing nested model datas as well
     this._initBaseModelData(modelName, id);
-    // TODO After the merge, we need to notify records, which may have been created
-    // prior to invoking didCommit
+    // Push the data stored in the projection to the base model as well
+    // TODO Push the attributes hash as well
     this._baseModelData.pushData({
       attributes: projectionData,
     });
     // we need to reset the __data as it will no longer be used
-    this.__data = null;
+    this._data = null;
   }
 
   _addChildModelData(key, isArray, modelData) {

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -644,7 +644,6 @@ export default class M3ModelData {
   }
 
   _inverseMergeUpdates(updates) {
-    // TODO Add more tests for this case
     // TODO Add support for nested objects
     if (!updates) {
       return;

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -217,17 +217,12 @@ export default class M3ModelData {
       changedKeys = this._filterChangedKeys(changedKeys);
     }
 
-    if (!this.id && jsonApiResource && jsonApiResource.id) {
+    let hasReceivedId = !this.id && jsonApiResource && jsonApiResource.id;
+    if (hasReceivedId) {
       this.id = '' + jsonApiResource.id;
       if (this._baseModelName) {
         // Fresh projection was saved, we need to connect it with the base model data
-        let projectionData = this._data;
-        this._initBaseModelData(this._baseModelName, this.id);
-        // TODO We only do this because there might be inflight attributes, which the server
-        // didn't include in the response
-        this._baseModelData._inverseMergeUpdates(projectionData);
-        // we need to reset the __data to reread it from the base model data
-        this.__data = null;
+        this._initBaseModelDataOnCommit(this._baseModelName, this.id);
       }
     }
 
@@ -497,6 +492,19 @@ export default class M3ModelData {
   _initBaseModelData(modelName, id) {
     this._baseModelData = this.storeWrapper.modelDataFor(modelName, id);
     this._baseModelData._registerProjection(this);
+  }
+
+  _initBaseModelDataOnCommit(modelName, id) {
+    // TODO Recursively init any existing nested model datas as well
+    let projectionData = this._data;
+    this._initBaseModelData(modelName, id);
+    // TODO We only do this because there might be inflight attributes, which the server
+    // didn't include in the response
+    // TODO After the merge, we need to notify records, which may have been created
+    // prior to invoking didCommit
+    this._baseModelData._inverseMergeUpdates(projectionData);
+    // we need to reset the __data to reread it from the base model data
+    this.__data = null;
   }
 
   _addChildModelData(key, isArray, modelData) {

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -498,12 +498,12 @@ export default class M3ModelData {
     // TODO Recursively init any existing nested model datas as well
     let projectionData = this._data;
     this._initBaseModelData(modelName, id);
-    // TODO We only do this because there might be inflight attributes, which the server
-    // didn't include in the response
     // TODO After the merge, we need to notify records, which may have been created
     // prior to invoking didCommit
-    this._baseModelData._inverseMergeUpdates(projectionData);
-    // we need to reset the __data to reread it from the base model data
+    this._baseModelData.pushData({
+      attributes: projectionData,
+    });
+    // we need to reset the __data as it will no longer be used
     this.__data = null;
   }
 
@@ -649,24 +649,6 @@ export default class M3ModelData {
     // if this model data is the last one in the projections list, then all of the others have been destroyed
     // note: should not be possible to get into state of no projections (projections.length === 0)
     return this._projections.length === 1 && this._projections[0] === this;
-  }
-
-  _inverseMergeUpdates(updates) {
-    // TODO Add support for nested objects
-    if (!updates) {
-      return;
-    }
-    let data = this._data;
-
-    let updatedKeys = Object.keys(updates);
-    for (let i = 0; i < updatedKeys.length; i++) {
-      let key = updatedKeys[i];
-
-      if (key in data) {
-        continue;
-      }
-      data[key] = updates[key];
-    }
   }
 
   /*

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -107,9 +107,11 @@ export default class M3ModelData {
     if (parentKey !== undefined && parentKey !== null) {
       this._parentModelData._addChildModelData(parentKey, parentValueIsArray, this);
     }
-    // TODO we may not have ID yet?
-    if (this._baseModelName) {
+
+    if (this._baseModelName && this.id) {
       this._initBaseModelData(this._baseModelName, id);
+    } else {
+      this._baseModelData = null;
     }
   }
 
@@ -213,6 +215,20 @@ export default class M3ModelData {
     if (attributes !== undefined) {
       changedKeys = this._mergeUpdates(attributes, commitDataAndNotify, true);
       changedKeys = this._filterChangedKeys(changedKeys);
+    }
+
+    if (!this.id && jsonApiResource && jsonApiResource.id) {
+      this.id = '' + jsonApiResource.id;
+      if (this._baseModelName) {
+        // Fresh projection was saved, we need to connect it with the base model data
+        let projectionData = this._data;
+        this._initBaseModelData(this._baseModelName, this.id);
+        // TODO We only do this because there might be inflight attributes, which the server
+        // didn't include in the response
+        this._baseModelData._inverseMergeUpdates(projectionData);
+        // we need to reset the __data to reread it from the base model data
+        this.__data = null;
+      }
     }
 
     this._updateChangedAttributes();
@@ -625,6 +641,25 @@ export default class M3ModelData {
     // if this model data is the last one in the projections list, then all of the others have been destroyed
     // note: should not be possible to get into state of no projections (projections.length === 0)
     return this.__projections.length === 1 && this.__projections[0] === this;
+  }
+
+  _inverseMergeUpdates(updates) {
+    // TODO Add more tests for this case
+    // TODO Add support for nested objects
+    if (!updates) {
+      return;
+    }
+    let data = this._data;
+
+    let updatedKeys = Object.keys(updates);
+    for (let i = 0; i < updatedKeys.length; i++) {
+      let key = updatedKeys[i];
+
+      if (key in data) {
+        continue;
+      }
+      data[key] = updates[key];
+    }
   }
 
   /*

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -332,7 +332,7 @@ export default class M3ModelData {
     if (this.isDestroyed) {
       return;
     }
-    if (this.baseModelData || this._areAllProjectionsDestroyed()) {
+    if (this._baseModelData || this._areAllProjectionsDestroyed()) {
       this._destroy();
     }
   }
@@ -564,14 +564,14 @@ export default class M3ModelData {
   }
 
   _unregisterProjection(modelData) {
-    if (!this.__projections) {
+    if (!this._projections) {
       return;
     }
-    let idx = this.__projections.indexOf(modelData);
+    let idx = this._projections.indexOf(modelData);
     if (idx === -1) {
       return;
     }
-    this.__projections.splice(idx, 1);
+    this._projections.splice(idx, 1);
 
     // if all projetions have been destroyed and the record is not use, destroy as well
     if (this._areAllProjectionsDestroyed() && !this.isRecordInUse()) {
@@ -582,8 +582,8 @@ export default class M3ModelData {
   _destroy() {
     this.isDestroyed = true;
     this.storeWrapper.disconnectRecord(this.modelName, this.id, this.clientId);
-    if (this.baseModelData) {
-      this.baseModelData._unregisterProjection(this);
+    if (this._baseModelData) {
+      this._baseModelData._unregisterProjection(this);
     }
   }
 
@@ -634,13 +634,13 @@ export default class M3ModelData {
   }
 
   _areAllProjectionsDestroyed() {
-    if (!this.__projections) {
+    if (!this._projections) {
       // no projections were ever registered
       return true;
     }
     // if this model data is the last one in the projections list, then all of the others have been destroyed
     // note: should not be possible to get into state of no projections (projections.length === 0)
-    return this.__projections.length === 1 && this.__projections[0] === this;
+    return this._projections.length === 1 && this._projections[0] === this;
   }
 
   _inverseMergeUpdates(updates) {

--- a/tests/unit/model-data-test.js
+++ b/tests/unit/model-data-test.js
@@ -29,6 +29,10 @@ module('unit/model-data', function(hooks) {
         delete this.modelDatas[key];
       },
 
+      isRecordInUse() {
+        return false;
+      },
+
       notifyPropertyChange() {},
     });
 
@@ -225,6 +229,25 @@ module('unit/model-data', function(hooks) {
       baseModelData._projections,
       [baseModelData, projectedModelData],
       'Expected projected model data to be in the projections list'
+    );
+  });
+
+  test('projection model data unregister from base model data and the store on unloadRecord', function(assert) {
+    let projectionModelData = this.storeWrapper.modelDataFor('com.bookstore.projected-book', '1');
+    let baseModelData = this.storeWrapper.modelDataFor('com.bookstore.book', '1');
+
+    // unload the model data
+    projectionModelData.unloadRecord();
+
+    assert.notEqual(
+      this.storeWrapper.disconnectedModelDatas[modelDataKey(projectionModelData)],
+      null,
+      'Expected projection model data to have been disconnected from the store'
+    );
+    assert.equal(
+      baseModelData._projections.find(x => x === projectionModelData),
+      null,
+      'Expected projected model data to have been removed from the projections'
     );
   });
 

--- a/tests/unit/model-data-test.js
+++ b/tests/unit/model-data-test.js
@@ -48,7 +48,9 @@ module('unit/model-data', function(hooks) {
       },
 
       computeBaseModelName(modelName) {
-        return modelName === 'com.bookstore.projected-book' ? 'com.bookstore.book' : null;
+        return ['com.bookstore.projected-book', 'com.bookstore.excerpt-book'].includes(modelName)
+          ? 'com.bookstore.book'
+          : null;
       },
     });
   });
@@ -248,6 +250,96 @@ module('unit/model-data', function(hooks) {
       baseModelData._projections.find(x => x === projectionModelData),
       null,
       'Expected projected model data to have been removed from the projections'
+    );
+  });
+
+  test('base model data is disconnected from the store if there are no more projections', function(assert) {
+    let projectionModelData = this.storeWrapper.modelDataFor('com.bookstore.projected-book', '1');
+    let baseModelData = this.storeWrapper.modelDataFor('com.bookstore.book', '1');
+
+    // unload the projection model data
+    projectionModelData.unloadRecord();
+
+    assert.notEqual(
+      this.storeWrapper.disconnectedModelDatas[modelDataKey(baseModelData)],
+      null,
+      'Expected projection model data to have been disconnected from the store'
+    );
+  });
+
+  test('base model data is not disconnected from the store if there are other projections', function(assert) {
+    let projectionModelData = this.storeWrapper.modelDataFor('com.bookstore.projected-book', '1');
+    this.storeWrapper.modelDataFor('com.bookstore.excerpt-book', '1');
+    let baseModelData = this.storeWrapper.modelDataFor('com.bookstore.book', '1');
+
+    // unload the projection model data
+    projectionModelData.unloadRecord();
+
+    assert.equal(
+      this.storeWrapper.disconnectedModelDatas[modelDataKey(baseModelData)],
+      null,
+      'Expected projection model data to not have been disconnected from the store'
+    );
+  });
+
+  test('base model data is not disconnected from the store if the record is in use', function(assert) {
+    this.storeWrapper.isRecordInUse = () => true;
+
+    let projectionModelData = this.storeWrapper.modelDataFor('com.bookstore.projected-book', '1');
+    let baseModelData = this.storeWrapper.modelDataFor('com.bookstore.book', '1');
+
+    // unload the projection model data
+    projectionModelData.unloadRecord();
+
+    assert.equal(
+      this.storeWrapper.disconnectedModelDatas[modelDataKey(baseModelData)],
+      null,
+      'Expected projection model data to have been disconnected from the store'
+    );
+  });
+
+  test('projection model data connects with base model data when committed with id', function(assert) {
+    let projectionModelData = this.storeWrapper.modelDataFor('com.bookstore.projected-book', null);
+
+    assert.equal(
+      this.storeWrapper.modelDatas[modelDataKey({ modelName: 'com.bookstore.book', id: null })],
+      null,
+      'Expected base model data to not have been created'
+    );
+
+    // actually set to be saved
+    projectionModelData.setAttr('name', 'Harry Potter');
+    projectionModelData.setAttr('preface', {
+      text: "Harry Potter's preface",
+    });
+
+    projectionModelData.willCommit();
+
+    projectionModelData.didCommit({
+      id: '1',
+      attributes: {},
+    });
+
+    let baseModelData = this.storeWrapper.modelDatas[
+      modelDataKey({ modelName: 'com.bookstore.book', id: '1' })
+    ];
+
+    assert.notEqual(baseModelData, null, 'Expected base model data to have been created');
+    assert.ok(
+      baseModelData._projections.find(x => x === projectionModelData),
+      'Expected projection model data to have been registered'
+    );
+    assert.equal(
+      projectionModelData.getAttr('name'),
+      'Harry Potter',
+      'Expected primitive attribute to have been retained'
+    );
+    assert.deepEqual(
+      projectionModelData.getAttr('preface'),
+      {
+        text: "Harry Potter's preface",
+      },
+      'Expected complex attribute to have been retained'
     );
   });
 

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1866,7 +1866,7 @@ module('unit/projection', function(hooks) {
       assert.equal(get(projectedExcerpt, 'title'), BOOK_TITLE);
     });
 
-    skip(`Unloading the base-record does not unload the projection`, function(assert) {
+    test(`Unloading the base-record does not unload the projection`, function(assert) {
       let { baseRecord, projectedPreview } = this.records;
 
       run(() => {

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -1962,6 +1962,8 @@ module('unit/projection', function(hooks) {
     const BOOK_TITLE_2 = 'Alice Through the Looking Glass';
     const BOOK_CHAPTER_1 = 'Down the Rabbit-Hole';
     const BOOK_CHAPTER_2 = 'Looking-Glass House';
+    const BOOK_AUTHOR_NAME_1 = 'Lewis Carol';
+    const BOOK_AUTHOR_NAME_2 = 'J.K. Rowling';
 
     test('independently created projections of the same base-type but no ID do not share their data', function(assert) {
       let projectedPreview = run(() =>
@@ -2069,7 +2071,7 @@ module('unit/projection', function(hooks) {
       });
     });
 
-    test('we can create and save a projection', function(assert) {
+    test('can create and save a projection', function(assert) {
       let createRecordCalls = 0;
 
       this.owner.register(
@@ -2178,7 +2180,13 @@ module('unit/projection', function(hooks) {
       let projectedPreview = run(() => {
         let record = this.store.createRecord(BOOK_PREVIEW_PROJECTION_CLASS_PATH, {
           title: BOOK_TITLE_1,
+          author: {
+            name: BOOK_AUTHOR_NAME_1,
+          },
         });
+
+        // reify the nested model
+        get(record, 'author.name');
 
         record.save();
         return record;
@@ -2192,6 +2200,9 @@ module('unit/projection', function(hooks) {
             type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
             attributes: {
               title: BOOK_TITLE_2,
+              author: {
+                name: BOOK_AUTHOR_NAME_2,
+              },
             },
           },
         });
@@ -2201,6 +2212,11 @@ module('unit/projection', function(hooks) {
         get(projectedPreview, 'title'),
         BOOK_TITLE_2,
         'Expected preview projection to have received updated title'
+      );
+      assert.equal(
+        get(projectedPreview, 'author.name'),
+        BOOK_AUTHOR_NAME_2,
+        'Expected preview projection to have received updated author.name'
       );
     });
 

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2159,7 +2159,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    skip('newly created and saved projections can receive updates', function(assert) {
+    test('newly created and saved projections can receive updates', function(assert) {
       this.owner.register(
         'adapter:-ember-m3',
         EmberObject.extend({


### PR DESCRIPTION
This is a rebase of the #62 PR.

The implementation is little crude, because it avoids using `clientId` to connect to the base ModelData immediately after the record is created. Instead it delays until the record is committed.

The refactoring to use `clientId` will come in a separate PR, because it is dependent on fixes in Ember Data.