### PR TITLE
Refactor to use clientId if id is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^2.0.2",
-    "ember-data": "emberjs/data#60ea116ac9ccf3868a62a3cfd05c4e23ec406763",
+    "ember-data": "dnachev/data#e8dd3301735dc103b8b4dd7c2f22453d22f2e3a4",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2278,9 +2278,9 @@ ember-cli@~3.0.2:
     watch-detector "^0.1.0"
     yam "0.0.22"
 
-ember-data@emberjs/data#60ea116ac9ccf3868a62a3cfd05c4e23ec406763:
+ember-data@dnachev/data#e8dd3301735dc103b8b4dd7c2f22453d22f2e3a4:
   version "3.1.0-canary"
-  resolved "https://codeload.github.com/emberjs/data/tar.gz/60ea116ac9ccf3868a62a3cfd05c4e23ec406763"
+  resolved "https://codeload.github.com/dnachev/data/tar.gz/e8dd3301735dc103b8b4dd7c2f22453d22f2e3a4"
   dependencies:
     amd-name-resolver "0.0.7"
     babel-plugin-ember-modules-api-polyfill "^1.4.2"


### PR DESCRIPTION
This is a refactoring on top #106 PR and it relies on two Ember Data fixes:

- `StoreWrapperAPI` must have a function to set server-side ID for the model data. This is because, when we save a projection, we receive the server-side ID through the projection model data instead of the base model data.
- `Store.updateId()` should remove the model data from the `_newlyCreated` hash, which is used for tracking client-only records
- `_newlyCreated` hash must be split by model name, because the projection model data and the base model data should use the same `clientId` for simplicity reasons.

The above fixes are just suggestions. Open to suggestions.