### PR TITLE
`queryURL` Adapter Hook

### DIFF
--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -851,4 +851,31 @@ module('unit/query-cache', function(hooks) {
     let promise2 = this.queryCache.queryURL('/uwot', options);
     assert.equal(promise1, promise2);
   });
+
+  test('.queryURL uses queryURL adapter hook if available', function(assert) {
+    let params = { param: 'paramValue' };
+
+    this.adapter.queryURL = this.sinon.stub().returns(
+      resolve({
+        data: {
+          id: '1',
+          type: 'something-or-other',
+          attributes: {},
+        },
+      })
+    );
+
+    // add cacheKey to confirm only select options are passed down
+    let options = { cacheKey: 'cached-value', params };
+
+    this.adapter.namespace = 'ns';
+    return this.queryCache.queryURL('test-url', options).then(() => {
+      assert.deepEqual(
+        stubCalls(this.adapter.queryURL),
+        [[this.adapter + '', ['/ns/test-url', 'GET', { params }]]],
+        'adapter.queryURL is called'
+      );
+      assert.equal(this.adapterAjax.called, false, '`adapter.ajax` is not called');
+    });
+  });
 });


### PR DESCRIPTION
An attempt at `queryURL` hook for the adapter, which gives slightly more flexibility in how queries against an URL are handled with the following signature:
`queryURL(url, method, options)`
where `options` is a subset of the options passed in to the `queryURL` function itself. Right now, only `params` are propagated, but in future, options the adapter might be interested in can be added.

I specifically avoided just passing the options, which are passed to `ajax()` as they are tight to jQuery and I don't think we should tie the API of this hook to something, which is being removed from Ember.

The other decision was the automatic fallback to the `ajax` in case the adapter does not implement the hook. Because all of the functionality can work without the adapter having to implement anything (except the `ajax` function, which is available on all adapters), I thought it's good idea to retain this convenience.