### PR TITLE
Do not resolve values from `setUnknownProperty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # ember-m3 changelog
 
-## 0.6.0 (unreleased)
+## 0.7.0 (unreleased)
+
+* breaking: Properties manually set, including those set in initial record
+  creation, are treated as resolved.  This means that
+  `createRecord({ myprop })` will not use transforms for `myprop`.
+
+* bugfix: now able to set `RecordArray` properties with `RecordArray` values.
+  Semantics are still update in-place, as when setting to arrays of models.
+
+## 0.6.0
 
 * breaking: To be consistent with the request types used in ember-data,
   `queryURL` will pass a `requestType` of `queryURL`.  Previously `query-url`

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -305,6 +305,10 @@ export default class M3ModelData {
     }
   }
 
+  hasLocalAttr(key) {
+    return key in this._attributes;
+  }
+
   unloadRecord() {
     if (this.isDestroyed) {
       return;

--- a/addon/record-array.js
+++ b/addon/record-array.js
@@ -1,4 +1,6 @@
+import { get } from '@ember/object';
 import { RecordArray } from 'ember-data/-private';
+import { A } from '@ember/array';
 
 export default RecordArray.extend({
   // TODO: implement more of RecordArray but make this not an arrayproxy
@@ -8,11 +10,12 @@ export default RecordArray.extend({
   },
 
   replaceContent(idx, removeAmt, newModels) {
-    let addAmt = newModels.length;
+    let _newModels = A(newModels);
+    let addAmt = get(_newModels, 'length');
 
     let newInternalModels = new Array(addAmt);
     for (let i = 0; i < newInternalModels.length; ++i) {
-      newInternalModels[i] = newModels.objectAt(i)._internalModel;
+      newInternalModels[i] = _newModels.objectAt(i)._internalModel;
     }
     this.content.replace(idx, removeAmt, newInternalModels);
     // TODO: update the backing m3's internalModel._data


### PR DESCRIPTION
Values that are set on the model directly (as opposed to ones that come from the
server payload) are treated as resolved.  This means that they do not go
through hooks like `schema.computeAttributeReference` for arrays of
references.

This also fixes a bug where setting an already-resolved `RecordArray`
would fail to update the `RecordArray` in-place if the new value was a
`RecordArray` of models (rather than a plain array of models).