### PR TITLE
Model Name normalizations

### DIFF
--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -482,7 +482,11 @@ export default class M3ModelData {
         return;
       }
 
-      this._baseModelData = this.storeWrapper.modelDataFor(baseModelName, this.id, this.clientId);
+      this._baseModelData = this.storeWrapper.modelDataFor(
+        dasherize(baseModelName),
+        this.id,
+        this.clientId
+      );
     }
 
     if (this._baseModelData) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -187,7 +187,7 @@ function resolveReferencesWithInternalModels(store, references) {
   return references.map(
     reference =>
       reference.type
-        ? store._internalModelForId(reference.type, reference.id)
+        ? store._internalModelForId(dasherize(reference.type), reference.id)
         : store._globalM3Cache[reference.id]
   );
 }

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -63,9 +63,9 @@ module('unit/model', function(hooks) {
             id,
           }));
         } else if (Array.isArray(value)) {
-          return value.every(v => v.id)
+          return value.every(v => typeof v === 'string')
             ? value.map(id => ({
-                type: null,
+                type: /^isbn:/.test(id) ? 'com.example.bookstore.Book' : null,
                 id,
               }))
             : undefined;
@@ -1512,7 +1512,7 @@ module('unit/model', function(hooks) {
     get(model, 'relatedBooks');
     assert.ok(model._cache['relatedBooks'] !== undefined, 'cache is updated upon invoking get');
     assert.equal(
-      get(model._cache['relatedBooks'][0], 'name'),
+      get(model._cache['relatedBooks'].objectAt(0), 'name'),
       'Harry Potter and the Chamber of Secrets',
       'cache is updated upon invoking get'
     );

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -20,9 +20,11 @@ const BOOK_EXCERPT_PROJECTION_CLASS_PATH = 'com.example.bookstore.projection.Boo
 const NORM_BOOK_EXCERPT_PROJECTION_CLASS_PATH = 'com.example.bookstore.projection.book-excerpt';
 const BOOK_PREVIEW_PROJECTION_CLASS_PATH = 'com.example.bookstore.projection.BookPreview';
 const NORM_BOOK_PREVIEW_PROJECTION_CLASS_PATH = 'com.example.bookstore.projection.book-preview';
+const PROJECTED_AUTHOR_CLASS = 'com.example.bookstore.projectedType.ProjectedAuthor';
 const NORM_PROJECTED_AUTHOR_CLASS = 'com.example.bookstore.projected-type.projected-author';
-const PUBLISHER_CLASS = 'com.example.bookstore.publisher';
-const PROJECTED_PUBLISHER_CLASS = 'com.example.bookstore.projectedType.projectedPublisher';
+const PUBLISHER_CLASS = 'com.example.bookstore.Publisher';
+const NORM_PUBLISHER_CLASS = 'com.example.bookstore.publisher';
+const PROJECTED_PUBLISHER_CLASS = 'com.example.bookstore.projectedType.ProjectedPublisher';
 const NORM_PROJECTED_PUBLISHER_CLASS = 'com.example.bookstore.projected-type.projected-publisher';
 
 module('unit/projection', function(hooks) {
@@ -86,21 +88,21 @@ module('unit/projection', function(hooks) {
       models: {
         [NORM_BOOK_CLASS_PATH]: {},
         [NORM_BOOK_EXCERPT_PROJECTION_CLASS_PATH]: {
-          baseType: NORM_BOOK_CLASS_PATH,
+          baseType: BOOK_CLASS_PATH,
           attributes: ['title', 'author', 'year', 'publisher'],
         },
         [NORM_BOOK_PREVIEW_PROJECTION_CLASS_PATH]: {
-          baseType: NORM_BOOK_CLASS_PATH,
+          baseType: BOOK_CLASS_PATH,
           attributesTypes: {
-            publisher: NORM_PROJECTED_PUBLISHER_CLASS,
-            author: NORM_PROJECTED_AUTHOR_CLASS,
-            otherBooksInSeries: NORM_BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+            publisher: PROJECTED_PUBLISHER_CLASS,
+            author: PROJECTED_AUTHOR_CLASS,
+            otherBooksInSeries: BOOK_PREVIEW_PROJECTION_CLASS_PATH,
           },
           // if you want to project an embedded model then it must have a type
           //  computedEmbeddedType
           attributes: ['title', 'author', 'chapter-1', 'year', 'publisher', 'otherBooksInSeries'],
         },
-        [PUBLISHER_CLASS]: {},
+        [NORM_PUBLISHER_CLASS]: {},
         // this schema must come with the parent schema
         [NORM_PROJECTED_AUTHOR_CLASS]: {
           attributes: ['location', 'name'],


### PR DESCRIPTION
There were two cases, where the schema had to do its own normalization (using `dasherize`) of the model names:
- Resolving a record array of references - M3 uses the internal `_internalModelForId` function, which expects a normalized model name. There is a small improvement to be made here to use `hasRecordForId` before trying to get the internal model as to not create an empty internal model if the reference is bad, but this is for another PR.
- Resolving base model data - `modelDataFor()` does not normalize the input, before creating the internal model, tracking the model data. This should probably be fixed in Ember Data itself, putting it here for illustration purposes.