### PR TITLE
Associate resolved values with tracked arrays

### DIFF
--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -27,10 +27,6 @@ export function extendStore(Store) {
       return get(this, '_schemaManager').includesModel(modelName) || this._super(modelName);
     },
 
-    modelFactoryFor(modelName) {
-      return this._modelFactoryFor(modelName);
-    },
-
     _modelFactoryFor(modelName) {
       if (get(this, '_schemaManager').includesModel(modelName)) {
         return MegamorphicModelFactory;

--- a/addon/m3-reference-array.js
+++ b/addon/m3-reference-array.js
@@ -14,9 +14,8 @@ export default class extends M3RecordArray {
 
   replaceContent(idx, removeAmt, newItems) {
     super.replaceContent(idx, removeAmt, newItems);
-    // update attr in model data
-    // and model state
-    this._model._setAttribute(this._key, this);
+    // update attr in model data and model state
+    this._model._setAttribute(this._key, this, true);
   }
 
   get length() {

--- a/addon/m3-tracked-array.js
+++ b/addon/m3-tracked-array.js
@@ -1,6 +1,7 @@
 import ArrayProxy from '@ember/array/proxy';
 import { get } from '@ember/object';
-import { resolveValue } from './resolve-attribute-util';
+import { isResolvedValue, resolveValue } from './resolve-attribute-util';
+import { associateRecordWithRecordArray } from './record-array';
 
 export default class extends ArrayProxy {
   init() {
@@ -18,20 +19,47 @@ export default class extends ArrayProxy {
   }
 
   replaceContent(idx, removeAmt, newItems) {
-    newItems = newItems.map(item =>
-      resolveValue(this._key, item, this._modelName, this._store, this._schema, this._model)
-    );
+    newItems = newItems.map((item, idx) => {
+      if (isResolvedValue(item)) {
+        associateRecordWithRecordArray(item, this);
+        return item;
+      }
+
+      return resolveValue(
+        this._key,
+        item,
+        this._modelName,
+        this._store,
+        this._schema,
+        this._model,
+        idx
+      );
+    });
 
     // Update content
     this.content.replace(idx, removeAmt, newItems);
 
-    // Set attribute in model data and
-    // update model state
-    // and changedAttributes object
-    this._model._setAttribute(this._key, this.content);
+    // Set attribute in model data and update model state and changedAttributes
+    // object
+    this._model._setAttribute(this._key, this.content, true);
   }
 
   get length() {
     return this.content && this.content.length !== undefined ? this.content.length : 0;
+  }
+
+  _removeInternalModels(internalModels) {
+    for (let i = this.content.length; i >= 0; --i) {
+      let item = this.content.objectAt(i);
+      if (isResolvedValue(item)) {
+        for (let j = 0; j < internalModels.length; ++j) {
+          let internalModel = internalModels[j];
+          if (internalModel === item._internalModel) {
+            this.content.removeAt(i);
+            break;
+          }
+        }
+      }
+    }
   }
 }

--- a/addon/model-data.js
+++ b/addon/model-data.js
@@ -28,6 +28,7 @@ class M3SchemaInterface {
     this.modelData = modelData;
     this._keyBeingResolved = null;
     this._refKeyDepkeyMap = {};
+    this._suppressNotifications = false;
   }
 
   _beginDependentKeyResolution(key) {
@@ -70,7 +71,7 @@ class M3SchemaInterface {
   }
 
   setAttr(key, value) {
-    this.modelData.setAttr(key, value);
+    this.modelData.setAttr(key, value, this._suppressNotifications);
   }
 }
 
@@ -275,7 +276,7 @@ export default class M3ModelData {
 
   setBelongsTo() {}
 
-  setAttr(key, value) {
+  setAttr(key, value, _suppressNotifications) {
     if (this._baseModelData) {
       return this._baseModelData.setAttr(key, value);
     }
@@ -295,7 +296,7 @@ export default class M3ModelData {
       this._attributes[key] = value;
     }
 
-    if (!this._notifyProjectionProperties([key])) {
+    if (!_suppressNotifications && !this._notifyProjectionProperties([key])) {
       this._notifyRecordProperties([key]);
     }
   }

--- a/addon/model.js
+++ b/addon/model.js
@@ -16,6 +16,7 @@ import {
   resolveValue,
   resolveReferencesWithInternalModels,
   computeAttributeReference,
+  isResolvedValue as _isResolvedValue,
 } from './resolve-attribute-util';
 
 const { propertyDidChange } = Ember;
@@ -76,10 +77,6 @@ export class EmbeddedInternalModel {
   createSnapshot() {
     return new EmbeddedSnapshot(this.record);
   }
-}
-
-function _isResolvedValue(value) {
-  return value && value.constructor && value.constructor.isModel;
 }
 
 function disallowAliasSet(object, key, value) {
@@ -418,9 +415,12 @@ export default class MegamorphicModel extends EmberObject {
     this._removeError(key);
   }
 
-  _setAttribute(attr, value) {
+  _setAttribute(attr, value, suppressNotifications = false) {
     const schemaInterface = this._internalModel._modelData.schemaInterface;
+    let priorSuppressNotifications = schemaInterface._suppressNotifications;
+    schemaInterface._suppressNotifications = suppressNotifications;
     this._schema.setAttribute(this._modelName, attr, value, schemaInterface);
+    schemaInterface._suppressNotifications = priorSuppressNotifications;
     const isDirty = this._internalModel._modelData.isAttrDirty(attr);
     if (isDirty && !this.get('isDirty')) {
       this._updateCurrentState(updatedUncommitted);

--- a/addon/record-array.js
+++ b/addon/record-array.js
@@ -62,3 +62,7 @@ export default class extends RecordArray {
 
   set length(v) {}
 }
+
+export function associateRecordWithRecordArray(record, recordArray) {
+  record._internalModel._recordArrays.add(recordArray);
+}

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -139,3 +139,7 @@ export function resolveReferencesWithInternalModels(store, references) {
         : store._globalM3Cache[reference.id]
   );
 }
+
+export function isResolvedValue(value) {
+  return value && value.constructor && value.constructor.isModel;
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-babel": "^6.3.0"
   },
   "peerDependencies": {
-    "ember-data": "~3.1.0"
+    "ember-data": ">= 3.3.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/unit/model/dependent-keys-test.js
+++ b/tests/unit/model/dependent-keys-test.js
@@ -35,7 +35,7 @@ module('unit/model/dependent-keys', function(hooks) {
         }
       },
 
-      computeNestedModel(/* key, value, modelName, data */) {},
+      computeNestedModel(/* key, value, modelName, schemaInterface */) {},
 
       models: {},
     });

--- a/tests/unit/model/tracked-array-test.js
+++ b/tests/unit/model/tracked-array-test.js
@@ -1,0 +1,142 @@
+import sinon from 'sinon';
+import { get } from '@ember/object';
+import { run } from '@ember/runloop';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { initialize as initializeStore } from 'ember-m3/initializers/m3-store';
+import M3TrackedArray from 'ember-m3/m3-tracked-array';
+
+module('unit/model/tracked-array', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.sinon = sinon.sandbox.create();
+    initializeStore(this);
+    this.store = this.owner.lookup('service:store');
+
+    this.schemaManager = this.owner.lookup('service:m3-schema-manager');
+    this.schemaManager.registerSchema({
+      includesModel(modelName) {
+        return /^com.example.bookstore\./i.test(modelName);
+      },
+
+      computeBaseModelName() {},
+
+      computeAttributeReference(/* key, value, modelName, schemaInterface */) {},
+
+      computeNestedModel(key, value /*, modelName, schemaInterface */) {
+        if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+          return {
+            attributes: value,
+          };
+        }
+      },
+
+      models: {},
+    });
+  });
+
+  test('tracked, non-reference, arrays resolve new values', function(assert) {
+    let model = run(() =>
+      this.store.push({
+        data: {
+          id: 'isbn:9780439708180',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: `Harry Potter and the Sorcerer's Stone`,
+            chapters: [
+              {
+                name: 'The Boy Who Lived',
+              },
+              2,
+            ],
+          },
+        },
+      })
+    );
+
+    let chapters = model.get('chapters');
+    assert.equal(chapters instanceof M3TrackedArray, true, 'chapters is a tracked array');
+
+    let chapter1 = chapters.objectAt(0);
+    assert.equal(chapter1.constructor.isModel, true, 'chapters has resolved values');
+    assert.equal(
+      chapter1.get('name'),
+      'The Boy Who Lived',
+      `chapters's embedded records can resolve values`
+    );
+
+    assert.equal(
+      chapters.objectAt(1),
+      2,
+      'chapters is a heterogenous mix of resolved and unresolved values'
+    );
+
+    run(() => chapters.pushObject(3));
+    assert.equal(chapters.objectAt(2), 3, `chapters accepts new values that don't resolve`);
+
+    run(() => chapters.pushObject({ name: 'The Vanishing Glass' }));
+
+    let chapter2 = chapters.objectAt(3);
+    assert.equal(chapter2.constructor.isModel, true, 'new values can be resolved');
+    assert.equal(get(chapter2, 'name'), 'The Vanishing Glass', `new values can be resolved`);
+  });
+
+  test('unloaded records are automatically removed from tracked arrays', function(assert) {
+    let model = run(() =>
+      this.store.push({
+        data: {
+          id: 'isbn:9780439708180',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: `Harry Potter and the Sorcerer's Stone`,
+            chapters: [],
+          },
+        },
+        included: [
+          {
+            id: 'isbn:9780439708180:chapter:1',
+            type: 'com.example.bookstore.Chapter',
+            attributes: {
+              name: 'The Boy Who Lived',
+            },
+          },
+          {
+            id: 'isbn:9780439708180:chapter:2',
+            type: 'com.example.bookstore.Chapter',
+            attributes: {
+              name: 'The Vanishing Glass',
+            },
+          },
+        ],
+      })
+    );
+
+    let chapter1 = this.store.peekRecord(
+      'com.example.bookstore.Chapter',
+      'isbn:9780439708180:chapter:1'
+    );
+    let chapter2 = this.store.peekRecord(
+      'com.example.bookstore.Chapter',
+      'isbn:9780439708180:chapter:2'
+    );
+    let chapters = model.get('chapters');
+
+    run(() => chapters.pushObject(chapter1));
+    run(() => chapters.pushObject(chapter2));
+
+    assert.deepEqual(
+      chapters.mapBy('name'),
+      ['The Boy Who Lived', 'The Vanishing Glass'],
+      'records are added to tracked arrays'
+    );
+
+    run(() => chapter2.unloadRecord());
+
+    assert.deepEqual(
+      chapters.mapBy('name'),
+      ['The Boy Who Lived'],
+      'unloaded records are removed from tracked arrays'
+    );
+  });
+});


### PR DESCRIPTION
In general this is not recommended, but it can help if it's difficult to determine whether the server payload should be interpreted as a tracked array or a record array (ie whether it's an array of nested models or a reference array).  If this is a problem it is most likely a problem for empty arrays.

Associating resolved values with tracked arrays means that in the tracked array case new records that are added will be removed when they're unloaded.