### PR TITLE
Keep nested model dirty state in sync.

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -104,7 +104,7 @@ class YesManAttributesSingletonClass {
 
 const YesManAttributes = new YesManAttributesSingletonClass();
 
-const retrieveFromCurrentState = computed('currentState', function(key) {
+const retrieveFromCurrentState = computed('_topModel.currentState', function(key) {
   return this._topModel._internalModel.currentState[key];
 }).readOnly();
 
@@ -180,6 +180,10 @@ export default class MegamorphicModel extends EmberObject {
   }
 
   _updateCurrentState(state) {
+    if (this !== this._topModel) {
+      this._topModel._updateCurrentState(state);
+      return;
+    }
     this._internalModel.currentState = state;
     notifyPropertyChange(this, 'currentState');
   }
@@ -498,5 +502,13 @@ export class EmbeddedMegamorphicModel extends MegamorphicModel {
 
   set id(value) {
     return this.setUnknownProperty('id', value);
+  }
+
+  static toString() {
+    return 'EmbeddedMegamorphicModel';
+  }
+
+  toString() {
+    return `<EmbeddedMegamorphicModel:${this.id}>`;
   }
 }

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -1,0 +1,94 @@
+import { module, test, skip } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import { run } from '@ember/runloop';
+import { isArray } from '@ember/array';
+
+import DefaultSchema from 'ember-m3/services/m3-schema';
+
+module('unit/model/state', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.store = this.owner.lookup('service:store');
+
+    class TestSchema extends DefaultSchema {
+      includesModel() {
+        return true;
+      }
+
+      computeAttributeReference(key, value, modelName, schemaInterface) {
+        let refValue = schemaInterface.getAttr(`*${key}`);
+        if (typeof refValue === 'string') {
+          return {
+            type: null,
+            id: refValue,
+          };
+        } else if (Array.isArray(refValue)) {
+          return refValue.map(x => ({
+            type: null,
+            id: x,
+          }));
+        }
+        return null;
+      }
+
+      computeNestedModel(key, value) {
+        if (value && typeof value === 'object' && value.constructor !== Date && !isArray(value)) {
+          return {
+            type: value.type,
+            id: value.id,
+            attributes: value,
+          };
+        }
+      }
+    }
+    this.owner.register('service:m3-schema', TestSchema);
+  });
+
+  skip('isEmpty', function() {});
+  skip('isLoading', function() {});
+  skip('isLoaded', function() {});
+  skip('isSaving', function() {});
+  skip('isDeleted', function() {});
+  skip('isNew', function() {});
+  skip('isValid', function() {});
+
+  test('isDirty', function(assert) {
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 1,
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: 'The Winds of Winter',
+            author: 'George R. R. Martin',
+            rating: {
+              avg: 10,
+            },
+          },
+        },
+      });
+    });
+
+    assert.equal(model.get('isDirty'), false, 'model not dirty');
+    assert.equal(model.get('rating.isDirty'), false, 'nested model not dirty');
+
+    model.set('author', 'Nobody yet');
+
+    assert.equal(model.get('isDirty'), true, 'model dirty');
+    assert.equal(model.get('rating.isDirty'), true, 'nested model shares dirty state with parent');
+
+    model.rollbackAttributes();
+
+    assert.equal(model.get('isDirty'), false, 'model no longer dirty');
+    assert.equal(model.get('rating.isDirty'), false, 'nested model no longer dirty');
+
+    model.set('rating.avg', 11);
+
+    assert.equal(model.get('isDirty'), true, 'model shares state with nested model');
+    assert.equal(model.get('rating.isDirty'), true, 'nested model dirty');
+  });
+
+  skip();
+});


### PR DESCRIPTION
Although initial values were computed from the top model, the computed property cache would not be properly invalidated when the top model's state changed.  Also the state changes of nested models would not be reflected in the top model.