### PR TITLE
Loosen the `setId` assertion

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -341,6 +341,10 @@ export default class MegamorphicModel extends EmberObject {
       return;
     }
 
+    if (value && value + '' === this.id) {
+      return;
+    }
+
     throw new Error(
       `You tried to set 'id' to '${value}' for '${
         this._modelName

--- a/tests/unit/model/api-test.js
+++ b/tests/unit/model/api-test.js
@@ -1,0 +1,53 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import DefaultSchema from 'ember-m3/services/m3-schema';
+
+module('unit/model/api', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.store = this.owner.lookup('service:store');
+
+    class TestSchema extends DefaultSchema {
+      includesModel() {
+        return true;
+      }
+    }
+    this.owner.register('service:m3-schema', TestSchema);
+  });
+
+  test('changing an id is not allowed, per ember data', function(assert) {
+    this.store.push({
+      data: {
+        id: 1,
+        type: 'com.example.Book',
+        attributes: {
+          name: 'The Storm Before the Storm',
+        },
+      },
+    });
+
+    let record = this.store.peekRecord('com.example.Book', 1);
+    assert.throws(() => {
+      record.set('id', 24601);
+    }, 'wat');
+  });
+
+  test('setting an id to itself is allowed', function(assert) {
+    this.store.push({
+      data: {
+        id: 1,
+        type: 'com.example.Book',
+        attributes: {
+          name: 'The Storm Before the Storm',
+        },
+      },
+    });
+
+    let record = this.store.peekRecord('com.example.Book', 1);
+    record.set('id', '1');
+
+    assert.equal(record.id, '1');
+  });
+});


### PR DESCRIPTION
It is valid to set a record's id to its current value.

[fix #202]