### PR TITLE
Fixing nested model updates from local updates and partial updates from server.

### DIFF
--- a/tests/unit/model/changed-attrs-test.js
+++ b/tests/unit/model/changed-attrs-test.js
@@ -734,13 +734,13 @@ module('unit/model/changed-attrs', function(hooks) {
 
       set(nestedModels.get('firstObject'), 'name', 'sooooooo super windy');
 
-      return savePromise.then(() => {
-        assert.deepEqual(
+      return savePromise.then(resolvedModel => {
+       assert.deepEqual(
           get(model, 'chapters').map(m => get(m, 'name')),
           ['The Boy Who Lived', 'The Vanishing Glass'],
           'local changes to nested models within arrays are not preserved after adapter commit'
-        );
-      });
+        )
+      );
     });
   });
 
@@ -783,8 +783,27 @@ module('unit/model/changed-attrs', function(hooks) {
     set(nestedModels.get('firstObject'), 'name', 'super windy');
     return run(() =>
       model.save().then(data => {
+        assert.deepEqual(data._internalModel._recordData._data, {
+          name: 'The Winds of Winter',
+          author: 'George R. R. Martin',
+          rating: 10,
+          expectedPubDate: 'never',
+          chapters: [
+            {
+              name: 'super windy',
+              number: 1,
+            },
+            {
+              name: `I guess winter was coming after all`,
+              number: 2,
+            },
+          ],
+        });
         assert.deepEqual(data.changedAttributes(), {}, 'changedAttributes is empty');
       })
     );
   });
 });
+
+// partial models
+// array and non-array

--- a/tests/unit/model/changed-attrs-test.js
+++ b/tests/unit/model/changed-attrs-test.js
@@ -10,6 +10,8 @@ import MegamorphicModel from 'ember-m3/model';
 import M3RecordArray from 'ember-m3/record-array';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 
+import { recordDataFor } from 'ember-m3/-private';
+
 module('unit/model/changed-attrs', function(hooks) {
   setupTest(hooks);
 
@@ -734,17 +736,79 @@ module('unit/model/changed-attrs', function(hooks) {
 
       set(nestedModels.get('firstObject'), 'name', 'sooooooo super windy');
 
-      return savePromise.then(resolvedModel => {
-       assert.deepEqual(
+      return savePromise.then(() => {
+        assert.deepEqual(
           get(model, 'chapters').map(m => get(m, 'name')),
           ['The Boy Who Lived', 'The Vanishing Glass'],
           'local changes to nested models within arrays are not preserved after adapter commit'
-        )
-      );
+        );
+      });
     });
   });
 
-  test('updates from .save clear changed attributes in nested models', function(assert) {
+  test('local nested model within non-array updates without server payload', function(assert) {
+    this.owner.register(
+      'adapter:-ember-m3',
+      EmberObject.extend({
+        updateRecord() {
+          return Promise.resolve();
+        },
+      })
+    );
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 1,
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: 'The Winds of Winter',
+            author: 'George R. R. Martin',
+            rating: 10,
+            expectedPubDate: 'never',
+            nextChapter: {
+              name: 'Chapter 1',
+              number: 1,
+              nextChapter: {
+                name: 'Chapter 2',
+                nunmber: 2,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    let doubleNestedModel = get(model, 'nextChapter.nextChapter');
+    set(doubleNestedModel, 'name', 'Chapter 3');
+    return run(() =>
+      model.save().then(data => {
+        assert.deepEqual(recordDataFor(data)._data, {
+          name: 'The Winds of Winter',
+          author: 'George R. R. Martin',
+          rating: 10,
+          expectedPubDate: 'never',
+          nextChapter: {
+            name: 'Chapter 1',
+            number: 1,
+            nextChapter: {
+              name: 'Chapter 3',
+              nunmber: 2,
+            },
+          },
+        });
+        doubleNestedModel = get(data, 'nextChapter.nextChapter');
+        assert.deepEqual(
+          doubleNestedModel.changedAttributes(),
+          {},
+          'doubleNestedModel has no changedAttributes'
+        );
+        assert.deepEqual(data.changedAttributes(), {}, 'changedAttributes is empty');
+      })
+    );
+  });
+
+  test('local nested model within array updates without server payload', function(assert) {
     this.owner.register(
       'adapter:-ember-m3',
       EmberObject.extend({
@@ -783,7 +847,7 @@ module('unit/model/changed-attrs', function(hooks) {
     set(nestedModels.get('firstObject'), 'name', 'super windy');
     return run(() =>
       model.save().then(data => {
-        assert.deepEqual(data._internalModel._recordData._data, {
+        assert.deepEqual(recordDataFor(data)._data, {
           name: 'The Winds of Winter',
           author: 'George R. R. Martin',
           rating: 10,
@@ -803,7 +867,341 @@ module('unit/model/changed-attrs', function(hooks) {
       })
     );
   });
-});
 
-// partial models
-// array and non-array
+  test('local nested model within non-array updates overriden by server payload', function(assert) {
+    this.owner.register(
+      'adapter:-ember-m3',
+      EmberObject.extend({
+        updateRecord() {
+          return Promise.resolve({
+            data: {
+              id: 1,
+              type: 'com.example.bookstore.Book',
+              attributes: {
+                name: 'The Winds of Winter',
+                author: 'George R. R. Martin',
+                rating: 10,
+                expectedPubDate: 'never',
+                nextChapter: {
+                  name: 'Chapter 3',
+                  number: 1,
+                  nextChapter: {
+                    name: 'Chapter 4',
+                  },
+                },
+              },
+            },
+          });
+        },
+      })
+    );
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 1,
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: 'The Winds of Winter',
+            author: 'George R. R. Martin',
+            rating: 10,
+            expectedPubDate: 'never',
+            nextChapter: {
+              name: 'Chapter 1',
+              number: 1,
+              nextChapter: {
+                name: 'Chapter 2',
+                number: 2,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    let doubleNestedModel = get(model, 'nextChapter.nextChapter');
+    set(doubleNestedModel, 'name', 'Chapter 3');
+    return run(() =>
+      model.save().then(data => {
+        assert.deepEqual(recordDataFor(data)._data, {
+          name: 'The Winds of Winter',
+          author: 'George R. R. Martin',
+          rating: 10,
+          expectedPubDate: 'never',
+          nextChapter: {
+            name: 'Chapter 3',
+            number: 1,
+            nextChapter: {
+              name: 'Chapter 4',
+              number: 2,
+            },
+          },
+        });
+        doubleNestedModel = get(data, 'nextChapter.nextChapter');
+        assert.deepEqual(
+          doubleNestedModel.changedAttributes(),
+          {},
+          'doubleNestedModel has no changedAttributes'
+        );
+        assert.deepEqual(data.changedAttributes(), {}, 'changedAttributes is empty');
+      })
+    );
+  });
+
+  test('local nested model within array updates overriden by server payload', function(assert) {
+    this.owner.register(
+      'adapter:-ember-m3',
+      EmberObject.extend({
+        updateRecord() {
+          return Promise.resolve({
+            data: {
+              id: 1,
+              type: 'com.example.bookstore.Book',
+              attributes: {
+                name: 'The Winds of Winter',
+                author: 'George R. R. Martin',
+                rating: 10,
+                expectedPubDate: 'never',
+                chapters: [
+                  {
+                    name: 'Chapter 4',
+                    number: 1,
+                  },
+                ],
+              },
+            },
+          });
+        },
+      })
+    );
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 1,
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: 'The Winds of Winter',
+            author: 'George R. R. Martin',
+            rating: 10,
+            expectedPubDate: 'never',
+            chapters: [
+              {
+                name: 'Chapter 1',
+                number: 1,
+              },
+              {
+                name: 'Chapter 2',
+                number: 2,
+              },
+            ],
+          },
+        },
+      });
+    });
+
+    let nestedModel = get(model, 'chapters');
+    set(nestedModel.get('firstObject'), 'name', 'super windy');
+    return run(() =>
+      model.save().then(data => {
+        assert.deepEqual(recordDataFor(data)._data, {
+          name: 'The Winds of Winter',
+          author: 'George R. R. Martin',
+          rating: 10,
+          expectedPubDate: 'never',
+          chapters: [
+            {
+              name: 'Chapter 4',
+              number: 1,
+            },
+          ],
+        });
+        assert.deepEqual(data.changedAttributes(), {}, 'changedAttributes is empty');
+      })
+    );
+  });
+
+  test('partial update from server and local changes for nested models within non-array', function(assert) {
+    this.owner.register(
+      'adapter:-ember-m3',
+      EmberObject.extend({
+        updateRecord() {
+          return Promise.resolve({
+            data: {
+              id: 'isbn:9780439708180',
+              type: 'com.example.bookstore.Book',
+              attributes: {
+                name: `Harry Potter and the Sorcerer's Stone`,
+                number: 0,
+                nextChapter: {
+                  name: 'The Boy Who whatever',
+                  number: 1,
+                },
+                authorNotes: {
+                  value: 'this book should sell well',
+                },
+              },
+            },
+          });
+        },
+      })
+    );
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'isbn:9780439708180',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: `Harry Potter and the Sorcerer's Stone`,
+            number: 0,
+            nextChapter: {
+              name: 'The Boy Who whatever',
+              number: 1,
+              nextChapter: {
+                name: 'The Vanishing dunno',
+                number: 2,
+              },
+            },
+            authorNotes: {
+              value: 'this book should sell well',
+            },
+          },
+        },
+      });
+    });
+
+    let doubleNestedModel = get(model, 'nextChapter.nextChapter');
+    set(doubleNestedModel, 'name', 'The Vanishing Boy');
+    return run(() =>
+      model.save().then(data => {
+        assert.deepEqual(recordDataFor(data)._data, {
+          name: `Harry Potter and the Sorcerer's Stone`,
+          number: 0,
+          nextChapter: {
+            name: 'The Boy Who whatever',
+            number: 1,
+            nextChapter: {
+              name: 'The Vanishing Boy',
+              number: 2,
+            },
+          },
+          authorNotes: {
+            value: 'this book should sell well',
+          },
+        });
+        doubleNestedModel = get(data, 'nextChapter.nextChapter');
+        assert.deepEqual(
+          doubleNestedModel.changedAttributes(),
+          {},
+          'doubleNestedModel has no changedAttributes'
+        );
+        assert.deepEqual(data.changedAttributes(), {}, 'changedAttributes is empty');
+      })
+    );
+  });
+
+  test('partial update from server and local changes for nested models within array', function(assert) {
+    this.owner.register(
+      'adapter:-ember-m3',
+      EmberObject.extend({
+        updateRecord() {
+          return Promise.resolve({
+            data: {
+              id: 'isbn:9780439708180',
+              type: 'com.example.bookstore.Book',
+              attributes: {
+                name: `Harry Potter and the Sorcerer's Stone`,
+                number: 0,
+                nextChapter: {
+                  number: 1,
+                  characters: [
+                    {
+                      name: 'Voldemort',
+                      number: 2,
+                    },
+                  ],
+                },
+                authorNotes: {
+                  value: 'this book should sell well',
+                },
+              },
+            },
+          });
+        },
+      })
+    );
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'isbn:9780439708180',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: `Harry Potter and the Sorcerer's Stone`,
+            number: 0,
+            nextChapter: {
+              name: 'The Boy Who whatever',
+              number: 1,
+              characters: [
+                {
+                  name: 'Harry Potter',
+                  number: 2,
+                },
+                {
+                  name: 'Ron',
+                  number: 3,
+                },
+              ],
+            },
+            authorNotes: {
+              value: 'this book should sell well',
+            },
+          },
+        },
+      });
+    });
+
+    let nestedModel = get(model, 'nextChapter');
+    let doubleNestedModel = get(nestedModel, 'characters');
+    run(() => {
+      set(nestedModel, 'name', 'The Boy Who Lived');
+      set(doubleNestedModel.get('firstObject'), 'name', 'Professor Snape');
+    });
+
+    return run(() =>
+      model.save().then(data => {
+        assert.deepEqual(recordDataFor(data)._data, {
+          name: `Harry Potter and the Sorcerer's Stone`,
+          number: 0,
+          nextChapter: {
+            name: 'The Boy Who Lived',
+            number: 1,
+            characters: [
+              {
+                name: 'Voldemort',
+                number: 2,
+              },
+            ],
+          },
+          authorNotes: {
+            value: 'this book should sell well',
+          },
+        });
+        nestedModel = get(data, 'nextChapter');
+        doubleNestedModel = get(nestedModel, 'characters');
+        assert.deepEqual(
+          nestedModel.changedAttributes(),
+          {},
+          'nestedModel has no changedAttributes'
+        );
+        assert.deepEqual(
+          doubleNestedModel.get('firstObject').changedAttributes(),
+          {},
+          'doubleNestedModel has no changedAttributes'
+        );
+        assert.deepEqual(data.changedAttributes(), {}, 'changedAttributes is empty');
+      })
+    );
+  });
+});

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -707,6 +707,7 @@ module('unit/record-data', function(hooks) {
       assert.deepEqual(
         zip(didCommitSpy.thisValues.slice(1).map(x => x + ''), didCommitSpy.args.slice(1)),
         [
+          [this.child2RecordData + '', []],
           [
             this.child1RecordData + '',
             [


### PR DESCRIPTION
Was able to reproduce a scenario where if you change a nested model and called save(), the changed attributes actually persist instead of being reset, so this new test will fail.

Investigation: Inside `willCommit`, we have `childRecordData.willCommit()` which never got called because childRecordData is an array of 2 elements, ~~which I think holds the old and new record.However, I'm not sure if the isArray check there is intentional for this scenario.~~ `DidCommit` only gets called once for the top-level model and the `_mergeUpdates()` call never happens.

Theoretically the test name above this new test was a bit misleading because it didn't actually test the changedAttribute() behavior at all.

