### PR TITLE
Copy deepcopy from Ember

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -1,7 +1,7 @@
 import { isEqual, isNone } from '@ember/utils';
 import { dasherize } from '@ember/string';
 import { assign, merge } from '@ember/polyfills';
-import { copy } from '@ember/object/internals';
+import { copy } from './utils/copy';
 import { assert } from '@ember/debug';
 import Ember from 'ember';
 import { IS_RECORD_DATA } from 'ember-compatibility-helpers';

--- a/addon/utils/copy.js
+++ b/addon/utils/copy.js
@@ -1,0 +1,54 @@
+function _copy(obj, seen, copies) {
+  // primitive data types are immutable, just return them.
+  if (typeof obj !== 'object' || obj === null) {
+    return obj;
+  }
+
+  let ret, loc;
+
+  // avoid cyclical loops
+  // eslint-disable-next-line no-cond-assign
+  if ((loc = seen.indexOf(obj) >= 0)) {
+    return copies[loc];
+  }
+
+  // IMPORTANT: this specific test will detect a native array only. Any other
+  // object will need to implement Copyable.
+  if (Array.isArray(obj)) {
+    ret = obj.slice();
+
+    loc = ret.length;
+
+    while (--loc >= 0) {
+      ret[loc] = copy(ret[loc], copies);
+    }
+  } else if (obj instanceof Date) {
+    ret = new Date(obj.getTime());
+  } else {
+    ret = {};
+    let key;
+    for (key in obj) {
+      // support Null prototype
+      if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+        continue;
+      }
+
+      // Prevents browsers that don't respect non-enumerability from
+      // copying internal Ember properties
+      if (key.substring(0, 2) === '__') {
+        continue;
+      }
+
+      ret[key] = copy(obj[key], seen, copies);
+    }
+  }
+
+  seen.push(obj);
+  copies.push(ret);
+
+  return ret;
+}
+
+export function copy(obj) {
+  return _copy(obj, [], []);
+}

--- a/tests/unit/utils/copy-test.js
+++ b/tests/unit/utils/copy-test.js
@@ -1,0 +1,49 @@
+import { module, test } from 'qunit';
+import { copy } from 'ember-m3/utils/copy';
+
+module('unit/utils/copy', function() {
+  test('copy deep copies', function(assert) {
+    let orig = {
+      a: '1',
+      b: {
+        c: [1, 2, 3],
+      },
+    };
+
+    let dupe = copy(orig);
+
+    assert.deepEqual(dupe, {
+      a: '1',
+      b: {
+        c: [1, 2, 3],
+      },
+    });
+
+    orig.b.c.push(4);
+    assert.deepEqual(orig.b.c, [1, 2, 3, 4], 'orig array updated');
+    assert.deepEqual(dupe.b.c, [1, 2, 3], 'dupe array not updated');
+
+    orig.b.q = 'hai';
+    assert.strictEqual(dupe.b.q, undefined, 'dupe nested object not updated');
+
+    let a = { b: {}, c: {} };
+    a.b.foo = { q: 'yes hello i am foo' };
+    a.c.foo = a.b.foo;
+
+    let acopy = copy(a);
+
+    assert.deepEqual(
+      acopy,
+      {
+        b: {
+          foo: { q: 'yes hello i am foo' },
+        },
+        c: {
+          foo: { q: 'yes hello i am foo' },
+        },
+      },
+      'graphs can be copied'
+    );
+    assert.notStrictEqual(acopy.b.foo, acopy.c.foo, 'graphs are copied as trees');
+  });
+});


### PR DESCRIPTION
Use this instead of ember's deprecated copy.  It's slightly tweaked to

1. ignore Copyable and
2. always be deep copy

Chief motivation is to remove the warnings