### PR TITLE
Fixes rollbackAttributes for record data from projections

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -511,6 +511,9 @@ export default class M3RecordData {
   }
 
   rollbackAttributes(notifyRecord = false) {
+    if (this._baseRecordData) {
+      return this._baseRecordData.rollbackAttributes(...arguments);
+    }
     let dirtyKeys;
     if (this.hasChangedAttributes()) {
       dirtyKeys = Object.keys(this._attributes);

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -559,6 +559,9 @@ export default class M3RecordData {
    * @returns {boolean}
    */
   isAttrDirty(key) {
+    if (this._baseRecordData) {
+      return this._baseRecordData.isAttrDirty(...arguments);
+    }
     if (this._attributes[key] === undefined) {
       return false;
     }

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2625,7 +2625,7 @@ module('unit/projection', function(hooks) {
       );
     });
 
-    test('.rollbackAttributes on a projection ', function(assert) {
+    test('.rollbackAttributes on a projection sets the model attributes back to its original state', function(assert) {
       let projectedExcerpt = run(() => {
         return this.store.push({
           data: {

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2625,6 +2625,69 @@ module('unit/projection', function(hooks) {
       );
     });
 
+    test('.rollbackAttributes on a projection ', function(assert) {
+      let projectedExcerpt = run(() => {
+        return this.store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            attributes: {
+              title: BOOK_TITLE_1,
+              author: {
+                name: BOOK_AUTHOR_NAME_1,
+              },
+            },
+          },
+        });
+      });
+      run(() => {
+        this.store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {
+              title: BOOK_TITLE_1,
+            },
+          },
+        });
+      });
+
+      assert.notOk(
+        projectedExcerpt.get('isDirty'),
+        'The projection should not be dirty on its initial state'
+      );
+      assert.deepEqual(
+        projectedExcerpt.changedAttributes(),
+        {},
+        'The projection should not have changed attributes on its initial state'
+      );
+      run(() => {
+        set(projectedExcerpt, 'title', BOOK_TITLE_2);
+      });
+      assert.ok(
+        projectedExcerpt.get('isDirty'),
+        'The projection should be dirty after mutating its state'
+      );
+      assert.deepEqual(
+        projectedExcerpt.changedAttributes(),
+        {
+          title: [BOOK_TITLE_1, BOOK_TITLE_2],
+        },
+        'The projection title was registered as a changed attribute after it was mutated'
+      );
+
+      projectedExcerpt.rollbackAttributes();
+      assert.notOk(
+        projectedExcerpt.get('isDirty'),
+        'The projection should not be dirty after rolling back its attributes'
+      );
+      assert.deepEqual(
+        projectedExcerpt.changedAttributes(),
+        {},
+        'The projection attributes went back to their original state after calling rollbackAttributes'
+      );
+    });
+
     skip('update and save of a projection does not touch non-whitelisted properties', function(assert) {
       let updateRecordCalls = 0;
       this.owner.register(

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2688,6 +2688,47 @@ module('unit/projection', function(hooks) {
       );
     });
 
+    test('.isDirty on a projection is true after updating its state', function(assert) {
+      let projectedExcerpt = run(() => {
+        return this.store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            attributes: {
+              title: BOOK_TITLE_1,
+              author: {
+                name: BOOK_AUTHOR_NAME_1,
+              },
+            },
+          },
+        });
+      });
+      // Base record
+      run(() => {
+        this.store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_CLASS_PATH,
+            attributes: {
+              title: BOOK_TITLE_1,
+            },
+          },
+        });
+      });
+
+      assert.notOk(
+        projectedExcerpt.get('isDirty'),
+        'The projection should not be dirty on its initial state'
+      );
+      run(() => {
+        set(projectedExcerpt, 'title', BOOK_TITLE_2);
+      });
+      assert.ok(
+        projectedExcerpt.get('isDirty'),
+        'The projection should be dirty after mutating its state'
+      );
+    });
+
     skip('update and save of a projection does not touch non-whitelisted properties', function(assert) {
       let updateRecordCalls = 0;
       this.owner.register(

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -198,6 +198,29 @@ module('unit/record-data', function(hooks) {
     assert.equal(rollbackAttributesSpy.getCalls().length, 0, 'rollbackAttributes was not called');
   });
 
+  test('.rollbackAttributes rolls backs the attributes on a base record data when dealing with a projection', function(assert) {
+    assert.expect(1);
+    const projectedRecordData = this.storeWrapper.recordDataFor(
+      'com.bookstore.projected-book',
+      '1'
+    );
+    const baseRecordData = this.storeWrapper.recordDatas[
+      recordDataKey({
+        modelName: 'com.bookstore.book',
+        id: '1',
+      })
+    ];
+    const rollbackAttributesSpy = this.sinon.spy(baseRecordData, 'rollbackAttributes');
+
+    projectedRecordData.rollbackAttributes();
+
+    assert.equal(
+      rollbackAttributesSpy.getCalls().length,
+      1,
+      'rollbackAttributes was called once for the base record data'
+    );
+  });
+
   test('.schemaInterface track dependent keys resolved by ref key', function(assert) {
     let recordData = this.mockRecordData();
     let schemaInterface = recordData.schemaInterface;

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -221,6 +221,25 @@ module('unit/record-data', function(hooks) {
     );
   });
 
+  test('.isAttrDirty returns true when the attribute is mutated on a projection', function(assert) {
+    assert.expect(2);
+    const projectedRecordData = this.storeWrapper.recordDataFor(
+      'com.bookstore.projected-book',
+      '1'
+    );
+    const attrName = 'name';
+
+    assert.notOk(
+      projectedRecordData.isAttrDirty(attrName),
+      'Fake attribute is not dirty initially'
+    );
+    projectedRecordData.setAttr(attrName, 'The best store in town');
+    assert.ok(
+      projectedRecordData.isAttrDirty(attrName),
+      'Fake attribute is dirty after being mutated'
+    );
+  });
+
   test('.schemaInterface track dependent keys resolved by ref key', function(assert) {
     let recordData = this.mockRecordData();
     let schemaInterface = recordData.schemaInterface;


### PR DESCRIPTION
Calling rollbackAttributes on a record data that has a base record data
was not working properly because the attributes mutated were in
the record data from the projection and not the base record data.

When dealing with projections all the interactions should be delegated
to the base record data.

In this PR I am adding a fix to call rollback attributes on the base
record data when one is present.

While adding a test for this I noticed that a similar bug was present in `isAttrDirty` which I've also addressed. 