### PR TITLE
hasLocaltAttr now delegates to base record

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -415,7 +415,11 @@ export default class M3RecordData {
    * @returns {boolean}
    */
   hasLocalAttr(key) {
-    return key in this._attributes;
+    if (this._baseRecordData) {
+      return this._baseRecordData.hasLocalAttr(key);
+    } else {
+      return key in this._attributes;
+    }
   }
 
   unloadRecord() {

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -583,6 +583,50 @@ module('unit/record-data', function(hooks) {
     );
   });
 
+  test('.hasLocalAttr validates the existance of key as part of the attributes of the record data', function(assert) {
+    let recordData = this.mockRecordData();
+    assert.notOk(
+      recordData.hasLocalAttr('name'),
+      'Name is not part of attributes because it has not been mutated'
+    );
+    recordData.setAttr('name', `Harry Potter and the Sorcerer's Stone`);
+    assert.ok(
+      recordData.hasLocalAttr('name'),
+      'Name is part of attributes because it has been mutated'
+    );
+  });
+
+  test('.hasLocalAttr validates the existance of key as part of the attributes of a base record data', function(assert) {
+    const projectedRecordData = this.storeWrapper.recordDataFor(
+      'com.bookstore.projected-book',
+      '1'
+    );
+    const baseRecordData = this.storeWrapper.recordDatas[
+      recordDataKey({
+        modelName: 'com.bookstore.book',
+        id: '1',
+      })
+    ];
+
+    assert.notOk(
+      baseRecordData.hasLocalAttr('name'),
+      'Name is not part of attributes of the base record because it has not been mutated'
+    );
+    assert.notOk(
+      projectedRecordData.hasLocalAttr('name'),
+      'Name is not part of attributes of the projected record because it has not been mutated'
+    );
+    projectedRecordData.setAttr('name', `Harry Potter and the Sorcerer's Stone`);
+    assert.ok(
+      baseRecordData.hasLocalAttr('name'),
+      'Name is part of attributes of the base record because it has been mutated'
+    );
+    assert.ok(
+      projectedRecordData.hasLocalAttr('name'),
+      'Name is part of attributes of the projected record because it has not been mutated'
+    );
+  });
+
   module('with nested models', function(hooks) {
     hooks.beforeEach(function() {
       this.topRecordData = new M3RecordData(


### PR DESCRIPTION
`hasLocalAttr` was not previously delegating to the base record data when
checking the attributes. This introduced problems with projections
because all mutations happen on the underlying base record so when cheking
for the existance of an attribute on a projection the result was always false. 

As part of the fix we now delegate to the base record `hasLocalAttr`
method when present.