### PR TITLE
Fix issues in deep copy

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -486,6 +486,7 @@ export default class M3RecordData {
     let serverState = this._data;
     let localChanges = this._attributes;
     let inFlightData = this._inFlightAttributes;
+    // TODO: test that we copy here
     let newData = emberAssign(copy(inFlightData), localChanges);
     let _changedAttributes = Object.create(null);
     let newDataKeys = Object.keys(newData);

--- a/tests/unit/utils/copy-test.js
+++ b/tests/unit/utils/copy-test.js
@@ -8,6 +8,9 @@ module('unit/utils/copy', function() {
       b: {
         c: [1, 2, 3],
       },
+      d: true,
+      e: false,
+      f: null,
     };
 
     let dupe = copy(orig);
@@ -17,7 +20,12 @@ module('unit/utils/copy', function() {
       b: {
         c: [1, 2, 3],
       },
+      d: true,
+      e: false,
+      f: null,
     });
+
+    assert.notEqual(orig.b, dupe.b, 'objects deep copied');
 
     orig.b.c.push(4);
     assert.deepEqual(orig.b.c, [1, 2, 3, 4], 'orig array updated');
@@ -44,6 +52,66 @@ module('unit/utils/copy', function() {
       },
       'graphs can be copied'
     );
-    assert.notStrictEqual(acopy.b.foo, acopy.c.foo, 'graphs are copied as trees');
+    assert.strictEqual(acopy.b.foo, acopy.c.foo, 'graphs copied directly');
+  });
+
+  test('copy deep copies top level object', function(assert) {
+    let orig = {};
+    let dupe = copy(orig);
+
+    assert.notEqual(dupe, orig, 'copied top level object');
+
+    orig = Object.create(null);
+    dupe = copy(orig);
+
+    assert.notEqual(dupe, orig, 'copied top level object (null prototype)');
+  });
+
+  test('deep copies cycles', function(assert) {
+    let orig = {
+      a: { b: 'b' },
+    };
+    orig.a.c = orig.a;
+
+    let dupe = copy(orig);
+
+    assert.strictEqual(dupe.a.c, dupe.a, 'cycle copied');
+    assert.notEqual(dupe.a.c, orig.a, 'cycle not a ref to original');
+    assert.equal(dupe.a.b, 'b', 'value copied');
+  });
+
+  test('copy shallow copies non-json values', function(assert) {
+    class SomethingOrOther {
+      constructor() {
+        this.x = 1;
+        this.y = 2;
+      }
+    }
+
+    let orig = {
+      s: new SomethingOrOther(),
+      a: 2,
+    };
+
+    let dupe = copy(orig);
+
+    assert.deepEqual(
+      JSON.parse(JSON.stringify(dupe)),
+      {
+        s: {
+          x: 1,
+          y: 2,
+        },
+        a: 2,
+      },
+      'deep copy with class instance value'
+    );
+
+    assert.strictEqual(orig.s, dupe.s, 'class instance not deep copied (value)');
+    assert.strictEqual(
+      dupe.s.constructor,
+      SomethingOrOther,
+      'class instance not deep copied (constructor)'
+    );
   });
 });


### PR DESCRIPTION
1. cycle detection was broken
2. it's not a generic copy utility: we don't need or want to copy
  non-JSON values which will sometimes appear in `attributes`.

It's perfectly fine for such values to be in `attributes` as they will
likely have serialization paths in users' serializers (eg if they are
models), but there is no need to copy such values when calculating
changed attributes.