### PR TITLE
Delegate `_destroyChildRecordData` to base

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -346,7 +346,7 @@ export default class M3RecordData {
    */
   setAttr(key, value, _suppressNotifications) {
     if (this._baseRecordData) {
-      return this._baseRecordData.setAttr(key, value);
+      return this._baseRecordData.setAttr(key, value, _suppressNotifications);
     }
 
     let originalValue;
@@ -769,6 +769,17 @@ export default class M3RecordData {
   }
 
   _destroyChildRecordData(key) {
+    if (this._baseRecordData) {
+      return this._baseRecordData._destroyChildRecordData(key);
+    }
+    if (!this.__childRecordDatas) {
+      return;
+    }
+
+    return this.__destroyChildRecordData(key);
+  }
+
+  __destroyChildRecordData(key) {
     if (!this.__childRecordDatas) {
       return;
     }
@@ -778,11 +789,12 @@ export default class M3RecordData {
       // destroy
       delete this._childRecordDatas[key];
     }
+
     if (this._projections) {
       // TODO Add a test for this destruction
       // start from 1 as we know the first projection is the recordData
       for (let i = 1; i < this._projections.length; i++) {
-        this._projections[i]._destroyChildRecordData(key);
+        this._projections[i].__destroyChildRecordData(key);
       }
     }
   }

--- a/tests/unit/model/projections/changed-attrs-test.js
+++ b/tests/unit/model/projections/changed-attrs-test.js
@@ -1,0 +1,91 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+
+module('unit/model/projections/changed-attrs', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.store = this.owner.lookup('service:store');
+
+    this.owner.register(
+      'service:m3-schema',
+      class TestSchema extends DefaultSchema {
+        includesModel() {
+          return true;
+        }
+
+        computeNestedModel(key, value) {
+          if (value !== null && typeof value === 'object') {
+            return { id: key, type: value.type, attributes: value };
+          }
+        }
+
+        computeBaseModelName(modelName) {
+          return ['com.bookstore.projected-book', 'com.bookstore.excerpt-book'].includes(modelName)
+            ? 'com.bookstore.book'
+            : null;
+        }
+      }
+    );
+  });
+
+  test('setting a dirty nested model (on projection) to null has correct changed attrs', function(assert) {
+    this.store.push({
+      data: [
+        {
+          id: 'urn:book:1',
+          type: 'com.bookstore.Book',
+          attributes: {
+            title: 'A History of the English Speaking Peoples Vol I',
+            randomChapter: {
+              position: 2,
+              title: 'Not actually a chapter in this book',
+            },
+          },
+        },
+        {
+          id: 'urn:book:1',
+          type: 'com.bookstore.ProjectedBook',
+        },
+      ],
+    });
+
+    let projectedRecord = this.store.peekRecord('com.bookstore.ProjectedBook', 'urn:book:1');
+
+    assert.equal(
+      projectedRecord.get('randomChapter.position'),
+      2,
+      'read properties from nested models'
+    );
+    assert.equal(
+      projectedRecord.get('randomChapter.title'),
+      'Not actually a chapter in this book',
+      'read properties from nested models'
+    );
+
+    // ensure the nested model itself has some changed attributes
+    projectedRecord.set('randomChapter.position', 3);
+    projectedRecord.set('randomChapter', null);
+
+    assert.strictEqual(
+      projectedRecord.get('randomChapter'),
+      null,
+      'nested model is cleared on projection'
+    );
+
+    assert.deepEqual(
+      projectedRecord.changedAttributes(),
+      {
+        randomChapter: [
+          {
+            position: 2,
+            title: 'Not actually a chapter in this book',
+          },
+          null,
+        ],
+      },
+      'changed attributes is correct'
+    );
+  });
+});


### PR DESCRIPTION
This function worked as expected for non-projections, but projections failed to delegate to their base record data, resulting in invalid state that among other things caused `changedAttributes` to be wrong in some cases.

[Fix #248]