### PR TITLE
feat: enable computeNestedModel to handle arrays

### DIFF
--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -113,6 +113,11 @@ function transferOrResolveValue(store, schema, record, recordData, modelName, ke
 }
 
 function createNestedModel(store, record, recordData, key, nestedValue, parentIdx = null) {
+  if (parentIdx !== null && nestedValue instanceof EmbeddedMegamorphicModel) {
+    recordData._setChildRecordData(key, parentIdx, recordDataFor(nestedValue));
+    return nestedValue;
+  }
+
   let internalModel = new EmbeddedInternalModel({
     // nested models with ids is pretty misleading; all they really ought to need is type
     id: nestedValue.id,
@@ -151,10 +156,6 @@ function createNestedModel(store, record, recordData, key, nestedValue, parentId
       nestedRecordData.setAttr(key, nestedValue.attributes[key], true);
     });
   }
-
-  // if (parentIdx !== null) {
-  //   recordData._setChildRecordData(key, parentIdx, nestedRecordData);
-  // }
 
   return nestedModel;
 }

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -76,7 +76,6 @@ export function resolveValue(key, value, modelName, store, schema, record, paren
 
   if (Array.isArray(nested)) {
     isArray = true;
-    value = nested;
     content = nested.map((v, i) => createNestedModel(store, record, recordData, key, v, i));
   } else if (nested) {
     content = createNestedModel(store, record, recordData, key, nested, parentIdx);
@@ -93,7 +92,6 @@ export function resolveValue(key, value, modelName, store, schema, record, paren
     return M3TrackedArray.create({
       content: A(content),
       key,
-      value, // why do we stash this here?
       modelName,
       store,
       schema,

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -11,31 +11,6 @@ import {
   resolveReferencesWithInternalModels,
 } from './utils/resolve';
 
-// ie an array of nested models
-export function resolveArray(key, value, modelName, store, schema, model, recordData) {
-  let resolvedArray = new Array(0);
-  if (value && value.length > 0) {
-    resolvedArray = value.map((value, idx) => {
-      if (value instanceof EmbeddedMegamorphicModel) {
-        recordData._setChildRecordData(key, idx, recordDataFor(value));
-        return value;
-      } else {
-        return resolveValue(key, value, modelName, store, schema, model, idx);
-      }
-    });
-  }
-
-  return M3TrackedArray.create({
-    content: A(resolvedArray),
-    key,
-    value,
-    modelName,
-    store,
-    schema,
-    model,
-  });
-}
-
 function resolveReference(store, reference) {
   if (reference.type === null) {
     // for schemas with a global id-space but multiple types, schemas may
@@ -95,51 +70,93 @@ export function resolveValue(key, value, modelName, store, schema, record, paren
     return resolveReferenceOrReferences(store, record, key, value, reference);
   }
 
-  if (Array.isArray(value)) {
-    return resolveArray(key, value, modelName, store, schema, record, recordData);
-  }
   let nested = computeNestedModel(key, value, modelName, schemaInterface, schema);
-  if (nested) {
-    let internalModel = new EmbeddedInternalModel({
-      // nested models with ids is pretty misleading; all they really ought to need is type
-      id: nested.id,
-      // maintain consistency with internalmodel.modelName, which is normalized
-      // internally within ember-data
-      modelName: nested.type ? dasherize(nested.type) : null,
-      parentInternalModel: record._internalModel,
-      parentKey: key,
-      parentIdx,
-    });
+  let content;
+  let isArray = false;
 
-    let nestedModel = new EmbeddedMegamorphicModel({
-      store,
-      _internalModel: internalModel,
-      _parentModel: record,
-      _topModel: record._topModel,
-    });
-    internalModel.record = nestedModel;
-
-    let nestedRecordData = recordDataFor(internalModel);
-
-    if (
-      !recordData.getServerAttr ||
-      (recordData.getServerAttr(key) !== null && recordData.getServerAttr(key) !== undefined)
-    ) {
-      nestedRecordData.pushData(
-        {
-          attributes: nested.attributes,
-        },
-        false,
-        false,
-        true
-      );
-    } else {
-      Object.keys(nested.attributes).forEach(key => {
-        nestedRecordData.setAttr(key, nested.attributes[key], true);
-      });
-    }
-    return nestedModel;
+  if (Array.isArray(nested)) {
+    isArray = true;
+    value = nested;
+    content = nested.map((v, i) => createNestedModel(store, record, recordData, key, v, i));
+  } else if (nested) {
+    content = createNestedModel(store, record, recordData, key, nested, parentIdx);
+  } else if (Array.isArray(value)) {
+    isArray = true;
+    content = value.map((v, i) =>
+      transferOrResolveValue(store, schema, record, recordData, modelName, key, v, i)
+    );
+  } else {
+    content = value;
   }
 
-  return value;
+  if (isArray === true) {
+    return M3TrackedArray.create({
+      content: A(content),
+      key,
+      value, // why do we stash this here?
+      modelName,
+      store,
+      schema,
+      model: record,
+    });
+  }
+
+  return content;
+}
+
+function transferOrResolveValue(store, schema, record, recordData, modelName, key, value, index) {
+  if (value instanceof EmbeddedMegamorphicModel) {
+    // transfer ownership to the new RecordData
+    recordData._setChildRecordData(key, index, recordDataFor(value));
+    return value;
+  }
+
+  return resolveValue(key, value, modelName, store, schema, record, index);
+}
+
+function createNestedModel(store, record, recordData, key, nestedValue, parentIdx = null) {
+  let internalModel = new EmbeddedInternalModel({
+    // nested models with ids is pretty misleading; all they really ought to need is type
+    id: nestedValue.id,
+    // maintain consistency with internalmodel.modelName, which is normalized
+    // internally within ember-data
+    modelName: nestedValue.type ? dasherize(nestedValue.type) : null,
+    parentInternalModel: record._internalModel,
+    parentKey: key,
+    parentIdx,
+  });
+
+  let nestedModel = new EmbeddedMegamorphicModel({
+    store,
+    _internalModel: internalModel,
+    _parentModel: record,
+    _topModel: record._topModel,
+  });
+  internalModel.record = nestedModel;
+
+  let nestedRecordData = recordDataFor(internalModel);
+
+  if (
+    !recordData.getServerAttr ||
+    (recordData.getServerAttr(key) !== null && recordData.getServerAttr(key) !== undefined)
+  ) {
+    nestedRecordData.pushData(
+      {
+        attributes: nestedValue.attributes,
+      },
+      false,
+      false,
+      true
+    );
+  } else {
+    Object.keys(nestedValue.attributes).forEach(key => {
+      nestedRecordData.setAttr(key, nestedValue.attributes[key], true);
+    });
+  }
+
+  // if (parentIdx !== null) {
+  //   recordData._setChildRecordData(key, parentIdx, nestedRecordData);
+  // }
+
+  return nestedModel;
 }

--- a/addon/services/m3-schema.js
+++ b/addon/services/m3-schema.js
@@ -14,8 +14,7 @@ export default class DefaultSchema extends Service {
   computeNestedModel(/* key, value, modelName, schemaInterface */) {
     // If the attribute with value `value` under key `key` of `modelName`
     // should be treated as a nested model instead of a plain POJO, then
-    // return `{ id, type, attributes }`.  Arrays will have this method
-    // invoked for each entry in the array, not for the array itself.
+    // return `{ id, type, attributes }`.
     //
     // For example with payload
     //
@@ -36,6 +35,17 @@ export default class DefaultSchema extends Service {
     // merely as a POJO.
     //
     // To have the attribute treated as a POJO return null.
+    //
+    // ## Arrays
+    //
+    // Arrays will have this method invoked for the top level
+    // where you have two choices.
+    //
+    // returning `null` will result in `computeNestedModel` being called
+    // for each individual entry in the array instead.
+    //
+    // alternatively, you may normalize the entire array at once,
+    // returning an array with its contents in jsonapi format.
     //
     return null;
   }

--- a/tests/dummy/app/services/m3-schema.js
+++ b/tests/dummy/app/services/m3-schema.js
@@ -22,6 +22,9 @@ export default class Schema extends DefaultSchema {
   }
 
   computeNestedModel(key, value) {
+    if (Array.isArray(value)) {
+      return null;
+    }
     if (typeof value === 'object' && value !== null && typeof value.$type === 'string') {
       return {
         id: value.isbn,

--- a/tests/unit/model/changed-attrs-test.js
+++ b/tests/unit/model/changed-attrs-test.js
@@ -1275,6 +1275,9 @@ module('unit/model/changed-attrs', function(hooks) {
         }
 
         computeNestedModel(key, value) {
+          if (Array.isArray(value)) {
+            return null;
+          }
           assert.ok(
             !(value instanceof MegamorphicModel),
             "We don't pass Megamorphic Models to computeNestedModel"

--- a/tests/unit/model/changed-attrs-test.js
+++ b/tests/unit/model/changed-attrs-test.js
@@ -1287,12 +1287,6 @@ module('unit/model/changed-attrs', function(hooks) {
             return { id: key, type: attributesType, attributes: value };
           }
         }
-
-        computeBaseModelName(modelName) {
-          return ['com.bookstore.projected-book', 'com.bookstore.excerpt-book'].includes(modelName)
-            ? 'com.bookstore.book'
-            : null;
-        }
       }
     );
 
@@ -1368,12 +1362,6 @@ module('unit/model/changed-attrs', function(hooks) {
           if (value !== null && typeof value === 'object') {
             return { id: key, type: attributesType, attributes: value };
           }
-        }
-
-        computeBaseModelName(modelName) {
-          return ['com.bookstore.projected-book', 'com.bookstore.excerpt-book'].includes(modelName)
-            ? 'com.bookstore.book'
-            : null;
         }
       }
     );

--- a/tests/unit/model/changed-attrs-test.js
+++ b/tests/unit/model/changed-attrs-test.js
@@ -1265,7 +1265,7 @@ module('unit/model/changed-attrs', function(hooks) {
     );
   });
 
-  test('Can set a many embedded property to a semi resolved array containing a mix of pojos and megamorphic models', function(assert) {
+  test('Can set a many embedded property to a semi resolved array containing a mix of pojos and megamorphic models (computeNestedModel does not handle array)', function(assert) {
     assert.expect(5);
     this.owner.register(
       'service:m3-schema',
@@ -1277,6 +1277,88 @@ module('unit/model/changed-attrs', function(hooks) {
         computeNestedModel(key, value) {
           if (Array.isArray(value)) {
             return null;
+          }
+          assert.ok(
+            !(value instanceof MegamorphicModel),
+            "We don't pass Megamorphic Models to computeNestedModel"
+          );
+          let attributesType = value && value.$type;
+          if (value !== null && typeof value === 'object') {
+            return { id: key, type: attributesType, attributes: value };
+          }
+        }
+
+        computeBaseModelName(modelName) {
+          return ['com.bookstore.projected-book', 'com.bookstore.excerpt-book'].includes(modelName)
+            ? 'com.bookstore.book'
+            : null;
+        }
+      }
+    );
+
+    this.store.push({
+      data: [
+        {
+          id: 'urn:book:1',
+          type: 'com.bookstore.Book',
+          attributes: {
+            locations: [
+              {
+                country: 'US',
+                geographicArea: 'California',
+                city: 'San Francisco',
+                postalCode: '94110',
+                description: 'Club house',
+                $type: 'OrganizationAddress',
+                headquarter: true,
+                line1: '1234 Lucky St',
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    let record = this.store.peekRecord('com.bookstore.Book', 'urn:book:1');
+
+    const currentCollection = record.get('locations').slice();
+    const aNewLocation = {
+      country: 'MX',
+      geographicArea: 'California',
+      city: 'Ensenada',
+      postalCode: '22810',
+      description: 'Home',
+      $type: 'OrganizationAddress',
+      headquarter: true,
+      line1: '555 Main St.',
+    };
+    record.set('locations', currentCollection.concat(aNewLocation));
+
+    let locations = record.get('locations');
+    assert.deepEqual(
+      locations.map(l => l.get('country')),
+      ['US', 'MX'],
+      'Locations retrieved succesfully'
+    );
+  });
+
+  test('Can set a many embedded property to a semi resolved array containing a mix of pojos and megamorphic models (computeNestedModel does handle array)', function(assert) {
+    assert.expect(5);
+    this.owner.register(
+      'service:m3-schema',
+      class TestSchema extends DefaultSchema {
+        includesModel() {
+          return true;
+        }
+
+        computeNestedModel(key, value) {
+          if (Array.isArray(value)) {
+            return value.map(v => {
+              if (v instanceof MegamorphicModel) {
+                return v;
+              }
+              return this.computeNestedModel(key, v);
+            });
           }
           assert.ok(
             !(value instanceof MegamorphicModel),

--- a/tests/unit/model/projections/changed-attrs-test.js
+++ b/tests/unit/model/projections/changed-attrs-test.js
@@ -18,6 +18,10 @@ module('unit/model/projections/changed-attrs', function(hooks) {
         }
 
         computeNestedModel(key, value) {
+          if (Array.isArray(value)) {
+            return null;
+          }
+
           if (value !== null && typeof value === 'object') {
             return { id: key, type: value.type, attributes: value };
           }
@@ -117,6 +121,9 @@ module('unit/model/projections/changed-attrs', function(hooks) {
         }
 
         computeNestedModel(key, value) {
+          if (Array.isArray(value)) {
+            return null;
+          }
           assert.ok(
             !(value instanceof MegamorphicModel),
             "We don't pass Megamorphic Models to computeNestedModel"
@@ -175,7 +182,6 @@ module('unit/model/projections/changed-attrs', function(hooks) {
     });
 
     let record = this.store.peekRecord('com.bookstore.ProjectedBook', 'urn:book:1');
-
     const currentCollection = record.get('locations').slice();
     const aNewLocation = {
       country: 'MX',


### PR DESCRIPTION
Previously if an array was not a reference array we did not give users a chance to handle it in-bulk vs by individual member. This makes extraction of some forms of schema information that needs to be either index-aware or aware that it is within a collection of some form difficult to detect. This change allows users to handle.

BREAKING: This change will break users who currently check for `value` in `computeNestedModel` being of type `object` but do not check whether it is an `Array`. The refactor is tiny, with the simplest refactor being to return `null` directly to maintain previous behavior.

e.g.

```js
computeNestedModel(key, value) {
  if (Array.isArray(value)) { return null; }
  // continue on ..
}
```