### PR TITLE
Feat: kill of Model dependence on EmberObject

### DIFF
--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -15,7 +15,7 @@ const STORE_OVERRIDES = {
   init() {
     this._super(...arguments);
     this._queryCache = new QueryCache({ store: this });
-    this._globalM3Cache = new Object(null);
+    this._globalM3Cache = Object.create(null);
   },
 
   // Store hooks necessary for using a single model class

--- a/addon/model.js
+++ b/addon/model.js
@@ -384,10 +384,6 @@ export default class MegamorphicModel {
       return;
     }
 
-    if (!this._init) {
-      console.log({ key, value });
-    }
-
     if (DEBUG) {
       assertNoChanges(this._store);
     }

--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -16,8 +16,8 @@ export default class QueryCache {
   constructor({ store }) {
     this._store = store;
     this._recordArrayManager = this._store.recordArrayManager;
-    this._queryCache = new Object(null);
-    this._reverseQueryCache = new Object(null);
+    this._queryCache = Object.create(null);
+    this._reverseQueryCache = Object.create(null);
     this.__adapter = null;
     this.__serializer = null;
   }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,11 +1,13 @@
 import { run } from '@ember/runloop';
-import { merge } from '@ember/polyfills';
+import { assign, merge } from '@ember/polyfills';
 import Application from '../../app';
 import config from '../../config/environment';
 
+const emberAssign = assign || merge;
+
 export default function startApp(attrs) {
-  let attributes = merge({}, config.APP);
-  attributes = merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = emberAssign({}, config.APP);
+  attributes = emberAssign(attributes, attrs); // use defaults, but you can override;
 
   return run(() => {
     let application = Application.create(attributes);

--- a/tests/unit/model/projections/changed-attrs-test.js
+++ b/tests/unit/model/projections/changed-attrs-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import MegamorphicModel from 'ember-m3/model';
-import { gte } from 'ember-compatibility-helpers';
 
 module('unit/model/projections/changed-attrs', function(hooks) {
   setupTest(hooks);

--- a/tests/unit/model/projections/changed-attrs-test.js
+++ b/tests/unit/model/projections/changed-attrs-test.js
@@ -96,11 +96,7 @@ module('unit/model/projections/changed-attrs', function(hooks) {
   });
 
   test('Can set a many embedded property to a semi resolved array containing a mix of pojos and megamorphic models - projections', async function(assert) {
-    if (gte('3.0.0')) {
-      assert.expect(4);
-    } else {
-      assert.expect(3);
-    }
+    assert.expect(3);
     this.owner.register(
       'adapter:-ember-m3',
       class TestAdapter {

--- a/tests/unit/query-array-test.js
+++ b/tests/unit/query-array-test.js
@@ -17,7 +17,7 @@ module('unit/query-array', function(hooks) {
     }();
 
     this.createRecordArray = function(options = {}) {
-      return new M3QueryArray(
+      return M3QueryArray.create(
         Object.assign(
           {
             store: this.store,

--- a/tests/unit/query-array-test.js
+++ b/tests/unit/query-array-test.js
@@ -60,7 +60,7 @@ module('unit/query-array', function(hooks) {
   });
 
   test('QueryArray requires a query', function(assert) {
-    let queryArray = new M3QueryArray();
+    let queryArray = M3QueryArray.create();
 
     assert.throws(() => {
       queryArray.update();

--- a/tests/unit/record-array-test.js
+++ b/tests/unit/record-array-test.js
@@ -40,7 +40,7 @@ module('unit/record-array', function(hooks) {
     });
 
     this.createRecordArray = function() {
-      let recordArray = new M3RecordArray();
+      let recordArray = M3RecordArray.create();
       recordArray.store = this.store;
       return recordArray;
     };


### PR DESCRIPTION
The deprecation noise was annoying (and slows down test runs a lot). I notice it when working with projects consuming ember-m3 and with ember-m3 itself.

We should do some more testing before merging that we don't have any other weird reliances on `EmberObject` inheritance, and that we make sure we do the right work in `destroy` (if there are things to do).