### PR TITLE
fix: bring back M3TrackedArray.value and deprecate

### DIFF
--- a/addon/m3-tracked-array.js
+++ b/addon/m3-tracked-array.js
@@ -4,6 +4,7 @@ import { resolveValue } from './resolve-attribute-util';
 import { isResolvedValue } from './utils/resolve';
 import { associateRecordWithRecordArray } from './record-array';
 import { recordDataFor } from './-private';
+import { deprecate } from '@ember/debug';
 
 /**
  * M3TrackedArray
@@ -15,11 +16,18 @@ export default class M3TrackedArray extends ArrayProxy {
   init() {
     super.init(...arguments);
     this._key = get(this, 'key');
-    this._value = get(this, 'value');
     this._modelName = get(this, 'modelName');
     this._store = get(this, 'store');
     this._schema = get(this, 'schema');
     this._record = get(this, 'model');
+  }
+
+  get value() {
+    deprecate('Accessing value on an M3TrackedArray was private and is deprecated.', false, {
+      id: 'm3.tracked-array.value',
+      until: '1.0',
+    });
+    return this._value;
   }
 
   replace(idx, removeAmt, newItems) {

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -92,6 +92,7 @@ export function resolveValue(key, value, modelName, store, schema, record, paren
     return M3TrackedArray.create({
       content: A(content),
       key,
+      _value: value,
       modelName,
       store,
       schema,


### PR DESCRIPTION
I noticed lots of failures due to trying to access `.value` in v-web when testing my recent change, so figured it best to bring this back with a deprecation.