### PR TITLE
feat: batch array changes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 **/blueprints/schema/files/app/services/m3-schema.js
+**/node_modules/**
 

--- a/addon/m3-reference-array.js
+++ b/addon/m3-reference-array.js
@@ -8,16 +8,8 @@ import M3RecordArray from './record-array';
  */
 export default class M3ReferenceArray extends M3RecordArray {
   replace(idx, removeAmt, newItems) {
-    this.replaceContent(idx, removeAmt, newItems);
-  }
-
-  replaceContent(idx, removeAmt, newItems) {
-    super.replaceContent(idx, removeAmt, newItems);
+    super.replace(idx, removeAmt, newItems);
     // update attr in recordData and model state
     this.record._setAttribute(this.key, this, true);
-  }
-
-  get length() {
-    return this.content && this.content.length !== undefined ? this.content.length : 0;
   }
 }

--- a/addon/model.js
+++ b/addon/model.js
@@ -414,7 +414,7 @@ export default class MegamorphicModel extends EmberObject {
 
     if (key in this._cache) {
       let recordArray = this._cache[key];
-      recordArray.replaceContent(0, get(recordArray, 'length'), models);
+      recordArray.replace(0, get(recordArray, 'length'), models);
     }
 
     // Remove errors upon setting

--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -1,7 +1,6 @@
 import { Promise as RSVPPromise } from 'rsvp';
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
-import { A } from '@ember/array';
 
 import MegamorphicModel from './model';
 import M3QueryArray from './query-array';
@@ -202,8 +201,8 @@ export default class QueryCache {
 
   _addResultToReverseCache(result, cacheKey) {
     if (result.constructor === M3QueryArray) {
-      for (let i = 0; i < result.content.length; ++i) {
-        this._addRecordToReverseCache(result.content[i], cacheKey);
+      for (let i = 0; i < result._internalModels.length; ++i) {
+        this._addRecordToReverseCache(result._internalModels[i], cacheKey);
       }
     } else {
       this._addRecordToReverseCache(result, cacheKey);
@@ -219,7 +218,6 @@ export default class QueryCache {
   _createQueryArray(internalModels, query) {
     let array = M3QueryArray.create({
       modelName: '-ember-m3',
-      content: A(),
       store: this._store,
       manager: this._recordArrayManager,
 
@@ -227,7 +225,7 @@ export default class QueryCache {
       query,
     });
 
-    array._setInternalModels(internalModels);
+    array._setInternalModels(internalModels, false);
 
     this._recordArrayManager._adapterPopulatedRecordArrays.push(array);
 

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -45,7 +45,7 @@ export function resolveRecordArray(store, record, key, references) {
 
   let internalModels = resolveReferencesWithInternalModels(store, references);
 
-  array._setInternalModels(internalModels);
+  array._setInternalModels(internalModels, false);
   return array;
 }
 

--- a/tests/integration/chain-watchers-test.js
+++ b/tests/integration/chain-watchers-test.js
@@ -7,6 +7,8 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { run } from '@ember/runloop';
 import M3TrackedArray from 'ember-m3/m3-tracked-array';
+import M3ReferenceArray from 'ember-m3/m3-reference-array';
+import { alias } from '@ember/object/computed';
 
 module('integration/chain-watchers', function(hooks) {
   setupRenderingTest(hooks);
@@ -44,19 +46,22 @@ module('integration/chain-watchers', function(hooks) {
         layout: hbs`
         Authors:
         <ul>
-        {{#each authors as |author|}}
-          <li>{{author.name}}</li>
+        {{#each authorNames as |authorName|}}
+          <li>{{authorName}}</li>
         {{/each}}
         </ul>
       `,
         bookstore: null,
+        bookstoreAuthors: computed('bookstore.books.[]', function() {
+          return this.get('bookstore.books').mapBy('author');
+        }),
+        authors: alias('bookstoreAuthors'),
         // this cp depends on books.[]
         // so when it's rendered in a template we'll have a chain watcher with
         // parent `books`, a property from an m3 record
-        authors: computed('bookstore.books.[]', function() {
-          let bookstore = this.get('bookstore');
-          let books = bookstore.get('books');
-          return books.mapBy('author');
+        authorNames: computed('authors.[]', function() {
+          let authors = this.get('authors');
+          return authors.mapBy('name');
         }),
       })
     );
@@ -148,6 +153,101 @@ module('integration/chain-watchers', function(hooks) {
       renderedAuthorNames,
       ['George R. R. Martin', 'Orson Scott Card'],
       'author names rerendered'
+    );
+  });
+
+  test('properties can update through reference arrays when chain watchers are active', async function(assert) {
+    this.store.pushPayload('com.example.Bookstore', {
+      data: {
+        id: 'urn:bookstore:1',
+        type: 'com.example.Bookstore',
+        attributes: {
+          '*books': ['urn:book:1', 'urn:book:2'],
+        },
+      },
+      included: [
+        {
+          id: 'urn:book:1',
+          type: 'com.example.Book',
+          attributes: {
+            author: {
+              name: 'Edward Gibbons',
+            },
+          },
+        },
+        {
+          id: 'urn:book:2',
+          type: 'com.example.Book',
+          attributes: {
+            author: {
+              name: 'Winston Churchill',
+            },
+          },
+        },
+      ],
+    });
+
+    let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
+
+    let resolvedBooks = bookstore.get('books');
+    assert.ok(resolvedBooks instanceof M3ReferenceArray, 'initially books is tracked array');
+    assert.equal(resolvedBooks.length, 2, 'initially 2 books');
+
+    this.set('bookstore', bookstore);
+    await render(hbs`
+      {{show-bookstore bookstore=bookstore}}
+    `);
+
+    let renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 2, '2 initial authors');
+    let renderedAuthorNames = Array.from(renderedItems).map(n => n.textContent);
+    assert.deepEqual(
+      renderedAuthorNames,
+      ['Edward Gibbons', 'Winston Churchill'],
+      'author names rendered initially'
+    );
+
+    run(() =>
+      this.store.pushPayload('com.example.Bookstore', {
+        data: [
+          {
+            id: 'urn:book:3',
+            type: 'com.example.Book',
+            attributes: {
+              author: {
+                name: 'George R. R. Martin',
+              },
+            },
+          },
+          {
+            id: 'urn:book:4',
+            type: 'com.example.Book',
+            attributes: {
+              author: {
+                name: 'Orson Scott Card',
+              },
+            },
+          },
+        ],
+        included: [
+          {
+            id: 'urn:bookstore:1',
+            type: 'com.example.Bookstore',
+            attributes: {
+              '*books': ['urn:book:3', 'urn:book:4'],
+            },
+          },
+        ],
+      })
+    );
+
+    renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 2, '2 updated authors');
+    renderedAuthorNames = Array.from(renderedItems).map(n => n.textContent);
+    assert.deepEqual(
+      renderedAuthorNames,
+      ['George R. R. Martin', 'Orson Scott Card'],
+      'author names rerendered after update'
     );
   });
 });

--- a/tests/integration/reference-array-test.js
+++ b/tests/integration/reference-array-test.js
@@ -1,0 +1,99 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+
+module('integration/reference-array', function(hooks) {
+  setupRenderingTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.owner.register(
+      'service:m3-schema',
+      class TestSchema extends DefaultSchema {
+        computeAttributeReference(key, value, modelName, schemaInterface) {
+          let refValue = schemaInterface.getAttr(`*${key}`);
+          if (typeof refValue === 'string') {
+            return {
+              type: null,
+              id: refValue,
+            };
+          } else if (Array.isArray(refValue)) {
+            return refValue.map(id => ({
+              type: null,
+              id,
+            }));
+          }
+
+          return undefined;
+        }
+        includesModel(modelName) {
+          return /^com\.example\./.test(modelName);
+        }
+      }
+    );
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('mutating reference arrays cause re-renders', async function(assert) {
+    this.store.pushPayload('com.example.Bookstore', {
+      data: {
+        id: 'urn:bookstore:1',
+        type: 'com.example.Bookstore',
+        attributes: {
+          '*books': ['urn:book:1', 'urn:book:2'],
+        },
+      },
+      included: [
+        {
+          id: 'urn:book:1',
+          type: 'com.example.Book',
+          author: {
+            name: 'Edward Gibbons',
+          },
+        },
+        {
+          id: 'urn:book:2',
+          type: 'com.example.Book',
+          author: {
+            name: 'Winston Churchill',
+          },
+        },
+        {
+          id: 'urn:book:3',
+          type: 'com.example.Book',
+          attributes: {
+            author: {
+              name: 'George R. R. Martin',
+            },
+          },
+        },
+      ],
+    });
+
+    let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
+    let books = bookstore.get('books');
+    this.set('bookstore', bookstore);
+    await render(hbs`
+      <ul>
+      {{#each this.bookstore.books as |book|}}
+        <li>Author: {{book.author.name}} </li>
+      {{/each}}
+      </ul>
+    `);
+
+    let renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 2, '2 initial authors');
+
+    books.popObject();
+    await settled();
+    renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 1, 'remove; re-render; now 1 author');
+
+    books.pushObject(this.store.peekRecord('com.example.Book', 'urn:book:3'));
+    books.pushObject(this.store.peekRecord('com.example.Book', 'urn:book:3'));
+    await settled();
+    renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 3, 'add two more books; re-render; now 3 authors');
+  });
+});

--- a/tests/unit/utils/notify-changes-test.js
+++ b/tests/unit/utils/notify-changes-test.js
@@ -1,0 +1,138 @@
+import { module, test } from 'qunit';
+import {
+  deferPropertyChange,
+  deferArrayPropertyChange,
+  flushChanges,
+} from 'ember-m3/utils/notify-changes';
+import { addObserver } from '@ember/object/observers';
+import { A } from '@ember/array';
+
+module('unit/utils/notify-changes', function(hooks) {
+  hooks.beforeEach(function() {
+    this.store = {};
+  });
+
+  test('deferPropertyChange + flushChanges batches property changes', function(assert) {
+    let a = { id: 'a' };
+    let b = { id: 'b' };
+    let changes = [];
+    addObserver(a, 'foo', () => changes.push([a, 'foo']));
+    addObserver(a, 'bar', () => changes.push([a, 'bar']));
+    addObserver(b, 'foo', () => changes.push([b, 'foo']));
+    addObserver(b, 'bar', () => changes.push([b, 'bar']));
+
+    deferPropertyChange(this.store, a, 'foo');
+    deferPropertyChange(this.store, a, 'bar');
+    deferPropertyChange(this.store, b, 'foo');
+    deferPropertyChange(this.store, b, 'bar');
+    // we wrap in `changeProperties` so will suppress duplicates
+    deferPropertyChange(this.store, a, 'foo');
+
+    assert.deepEqual(changes, [], 'observers have not been triggered');
+    flushChanges(this.store);
+    assert.deepEqual(
+      changes,
+      [[a, 'foo'], [a, 'bar'], [b, 'foo'], [b, 'bar']],
+      'changes triggered in order'
+    );
+  });
+
+  test('deferArrayPropertyChange + flushChanges batches array property changes', function(assert) {
+    let a = A();
+    let b = A();
+    a.id = 'a';
+    b.id = 'b';
+    let changes = [];
+
+    let observers = {
+      willChange(/* target, idx, deleteCount, addCount */) {
+        assert.notOk(true, `array willChange is not triggered with m3's property batching`);
+      },
+
+      didChange(target, idx, deleteCount, addCount) {
+        changes.push([this.id, target.id, 'didChange', idx, deleteCount, addCount]);
+      },
+    };
+    a.addArrayObserver(a, observers);
+    b.addArrayObserver(b, observers);
+
+    deferArrayPropertyChange(this.store, a, 0, 1, 2);
+    deferArrayPropertyChange(this.store, a, 1, 2, 3);
+    // there's no de-duping with array changes
+    deferArrayPropertyChange(this.store, b, 0, 1, 2);
+    deferArrayPropertyChange(this.store, b, 0, 1, 2);
+
+    assert.deepEqual(changes, [], 'observers have not been triggered');
+    flushChanges(this.store);
+    assert.deepEqual(
+      changes,
+      [
+        ['a', 'a', 'didChange', 0, 1, 2],
+        ['a', 'a', 'didChange', 1, 2, 3],
+        ['b', 'b', 'didChange', 0, 1, 2],
+        ['b', 'b', 'didChange', 0, 1, 2],
+      ],
+      'changes triggered in order'
+    );
+  });
+
+  test('simple and array property changes can be batched together', function(assert) {
+    let a = { id: 'a' };
+    let b = A();
+    b.id = 'b';
+    let changes = [];
+
+    let observers = {
+      willChange(/* target, idx, deleteCount, addCount */) {
+        assert.notOk(true, `array willChange is not triggered with m3's property batching`);
+      },
+
+      didChange(target, idx, deleteCount, addCount) {
+        changes.push([this.id, target.id, 'didChange', idx, deleteCount, addCount]);
+      },
+    };
+    b.addArrayObserver(b, observers);
+    addObserver(a, 'foo', () => changes.push([a, 'foo']));
+    addObserver(a, 'bar', () => changes.push([a, 'bar']));
+
+    deferPropertyChange(this.store, a, 'foo');
+    deferArrayPropertyChange(this.store, b, 0, 1, 2);
+    deferPropertyChange(this.store, a, 'bar');
+    deferArrayPropertyChange(this.store, b, 1, 2, 3);
+
+    assert.deepEqual(changes, [], 'observers have not been triggered');
+    flushChanges(this.store);
+    assert.deepEqual(
+      changes,
+      [
+        // array changes are eager, so batching within `changeProperties` has no effect here
+        ['b', 'b', 'didChange', 0, 1, 2],
+        ['b', 'b', 'didChange', 1, 2, 3],
+        [a, 'foo'],
+        [a, 'bar'],
+      ],
+      'changes triggered in order, but array changes happen first'
+    );
+  });
+
+  test('deferArrayPropertyChange asserts if passed a non-Ember array', function(assert) {
+    assert.throws(
+      () => {
+        deferArrayPropertyChange(this.store, {}, 1, 2, 3);
+      },
+      /deferArrayPropertyChange called on something other than an Ember array/,
+      'assert if passed non-array'
+    );
+
+    assert.throws(
+      () => {
+        deferArrayPropertyChange(this.store, [], 1, 2, 3);
+      },
+      /deferArrayPropertyChange called on something other than an Ember array/,
+      'assert if passed native array with prototype extensions off'
+    );
+
+    // does not throw
+    deferArrayPropertyChange(this.store, A(), 1, 2, 3);
+  });
+});


### PR DESCRIPTION
Previously only property changes were batched; now array changes in
record arrays are also batched.  Note that this is not the case for
tracked arrays, but this feature should be added there as well.

As part of this change, remove `ArrayProxy` as the base class of
`RecordArray`.  Although our arrays are array proxies, the base class is
not adding value and it's easier to implement all of the logic
ourselves.