### PR TITLE
fix #122

### DIFF
--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -8,6 +8,7 @@ import M3RecordData from '../record-data';
 import MegamorphicModelFactory from '../factory';
 import QueryCache from '../query-cache';
 import { flushChanges } from '../utils/notify-changes';
+import { dasherize } from '@ember/string';
 
 const STORE_OVERRIDES = {
   _schemaManager: inject('m3-schema-manager'),
@@ -102,8 +103,14 @@ const STORE_OVERRIDES = {
 
   _pushInternalModel(jsonAPIResource) {
     let internalModel = this._super(jsonAPIResource);
-    if (get(this, '_schemaManager').includesModel(jsonAPIResource.type)) {
-      this._globalM3Cache[internalModel.id] = internalModel;
+    let schemaManager = get(this, '_schemaManager');
+    let { type } = jsonAPIResource;
+    if (schemaManager.includesModel(type)) {
+      let baseName = schemaManager.computeBaseModelName(dasherize(type));
+      if (baseName === null || baseName === undefined) {
+        // only populate base records in the global cache
+        this._globalM3Cache[internalModel.id] = internalModel;
+      }
     }
     return internalModel;
   },

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -1,5 +1,3 @@
-import { A } from '@ember/array';
-import { run } from '@ember/runloop';
 import DS from 'ember-data';
 import { module, test, skip } from 'qunit';
 import { setupTest } from 'ember-qunit';
@@ -33,95 +31,6 @@ module('unit/store', function(hooks) {
 
   hooks.afterEach(function() {
     this.sinon.restore();
-  });
-
-  test('records are added to, and unloaded from, the global m3 cache', function(assert) {
-    run(() =>
-      this.store.push({
-        data: [
-          {
-            id: 'isbn:9780439708180',
-            type: 'com.example.bookstore.Book',
-          },
-          {
-            id: 'isbn:9780439708180/chapter/1',
-            type: 'com.example.bookstore.Chapter',
-          },
-          {
-            id: 'isbn:9780439064873',
-            type: 'com.example.bookstore.Book',
-          },
-          {
-            id: 'isbn:9780439708180/chapter/2',
-            type: 'com.example.bookstore.Chapter',
-          },
-          {
-            id: 'author:1',
-            type: 'author',
-            attributes: {
-              name: 'JK Rowling',
-            },
-          },
-        ],
-      })
-    );
-
-    assert.deepEqual(
-      Object.keys(this.store._identityMap._map).sort(),
-      ['author', 'com.example.bookstore.book', 'com.example.bookstore.chapter'],
-      'Identity map contains expected types'
-    );
-
-    let bookIds = A(this.store._internalModelsFor('com.example.bookstore.book')._models).mapBy(
-      'id'
-    );
-
-    assert.deepEqual(
-      bookIds,
-      ['isbn:9780439708180', 'isbn:9780439064873'],
-      'Identity map contains expected models - book'
-    );
-
-    let chapterIds = A(
-      this.store._internalModelsFor('com.example.bookstore.chapter')._models
-    ).mapBy('id');
-
-    assert.deepEqual(
-      chapterIds,
-      ['isbn:9780439708180/chapter/1', 'isbn:9780439708180/chapter/2'],
-      'Identity map contains expected models - chapter'
-    );
-
-    assert.equal(this.store.hasRecordForId('author', 'author:1'), true);
-
-    assert.deepEqual(
-      Object.keys(this.store._globalM3Cache).sort(),
-      [
-        'isbn:9780439064873',
-        'isbn:9780439708180',
-        'isbn:9780439708180/chapter/1',
-        'isbn:9780439708180/chapter/2',
-      ],
-      'global cache contains all m3 models, but no ds models'
-    );
-
-    run(() =>
-      this.store.peekRecord('com.example.bookstore.Book', 'isbn:9780439708180').unloadRecord()
-    );
-
-    assert.deepEqual(
-      Object.keys(this.store._globalM3Cache).sort(),
-      ['isbn:9780439064873', 'isbn:9780439708180/chapter/1', 'isbn:9780439708180/chapter/2'],
-      'global cache can unload records'
-    );
-
-    run(() => this.store.unloadAll());
-
-    assert.deepEqual(
-      Object.keys(this.store._globalM3Cache),
-      [],
-      'global cache can unload all records'
-    );
   });
 
   test('pushPayload batches change notifications', function(assert) {

--- a/tests/unit/store/global-cache-test.js
+++ b/tests/unit/store/global-cache-test.js
@@ -1,0 +1,225 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+import DS from 'ember-data';
+import { A } from '@ember/array';
+import sinon from 'sinon';
+
+module('unit/store/global-cache', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.sinon = sinon.createSandbox();
+
+    this.Author = DS.Model.extend({
+      name: DS.attr('string'),
+    });
+    this.Author.toString = () => 'Author';
+    this.owner.register('model:author', this.Author);
+
+    this.owner.register(
+      'service:m3-schema',
+      class TestSchema extends DefaultSchema {
+        _isProjection(modelName) {
+          return /-projection$/i.test(modelName);
+        }
+
+        includesModel(modelName) {
+          return /^com.example.bookstore\./i.test(modelName);
+        }
+
+        computeAttributeReference(key, value, modelName, schemaInterface) {
+          let refId = schemaInterface.getAttr(`*${key}`);
+          if (refId !== undefined) {
+            let type = this._isProjection(modelName)
+              ? 'com.example.bookstore.BookProjection'
+              : null;
+
+            return {
+              id: refId,
+              type,
+            };
+          }
+        }
+
+        computeBaseModelName(normalizedProjectionModelName) {
+          if (this._isProjection(normalizedProjectionModelName)) {
+            return normalizedProjectionModelName.substring(
+              0,
+              normalizedProjectionModelName.length - '-projection'.length
+            );
+          }
+        }
+      }
+    );
+    this.store = this.owner.lookup('service:store');
+  });
+
+  hooks.afterEach(function() {
+    this.sinon.restore();
+  });
+
+  test('records are added to, and unloaded from, the global m3 cache', function(assert) {
+    run(() =>
+      this.store.push({
+        data: [
+          {
+            id: 'isbn:9780439708180',
+            type: 'com.example.bookstore.Book',
+          },
+          {
+            id: 'isbn:9780439708180/chapter/1',
+            type: 'com.example.bookstore.Chapter',
+          },
+          {
+            id: 'isbn:9780439064873',
+            type: 'com.example.bookstore.Book',
+          },
+          {
+            id: 'isbn:9780439708180/chapter/2',
+            type: 'com.example.bookstore.Chapter',
+          },
+          {
+            id: 'author:1',
+            type: 'author',
+            attributes: {
+              name: 'JK Rowling',
+            },
+          },
+        ],
+      })
+    );
+
+    assert.deepEqual(
+      Object.keys(this.store._identityMap._map).sort(),
+      ['author', 'com.example.bookstore.book', 'com.example.bookstore.chapter'],
+      'Identity map contains expected types'
+    );
+
+    let bookIds = A(this.store._internalModelsFor('com.example.bookstore.book')._models).mapBy(
+      'id'
+    );
+
+    assert.deepEqual(
+      bookIds,
+      ['isbn:9780439708180', 'isbn:9780439064873'],
+      'Identity map contains expected models - book'
+    );
+
+    let chapterIds = A(
+      this.store._internalModelsFor('com.example.bookstore.chapter')._models
+    ).mapBy('id');
+
+    assert.deepEqual(
+      chapterIds,
+      ['isbn:9780439708180/chapter/1', 'isbn:9780439708180/chapter/2'],
+      'Identity map contains expected models - chapter'
+    );
+
+    assert.equal(this.store.hasRecordForId('author', 'author:1'), true);
+
+    assert.deepEqual(
+      Object.keys(this.store._globalM3Cache).sort(),
+      [
+        'isbn:9780439064873',
+        'isbn:9780439708180',
+        'isbn:9780439708180/chapter/1',
+        'isbn:9780439708180/chapter/2',
+      ],
+      'global cache contains all m3 models, but no ds models'
+    );
+
+    run(() =>
+      this.store.peekRecord('com.example.bookstore.Book', 'isbn:9780439708180').unloadRecord()
+    );
+
+    assert.deepEqual(
+      Object.keys(this.store._globalM3Cache).sort(),
+      ['isbn:9780439064873', 'isbn:9780439708180/chapter/1', 'isbn:9780439708180/chapter/2'],
+      'global cache can unload records'
+    );
+
+    run(() => this.store.unloadAll());
+
+    assert.deepEqual(
+      Object.keys(this.store._globalM3Cache),
+      [],
+      'global cache can unload all records'
+    );
+  });
+
+  test('projections are not added to the global m3 cache', function(assert) {
+    run(() =>
+      this.store.push({
+        data: {
+          type: 'com.example.bookstore.Book',
+          id: 'urn:book:1',
+          attributes: {
+            title: 'A History of the English Speaking Peoples',
+            '*otherBook': 'urn:book:2',
+          },
+        },
+        included: [
+          {
+            type: 'com.example.bookstore.Book',
+            id: 'urn:book:2',
+            attributes: {
+              title: 'The 30 Years War',
+            },
+          },
+          {
+            type: 'com.example.bookstore.BookProjection',
+            id: 'urn:book:1',
+          },
+          {
+            type: 'com.example.bookstore.BookProjection',
+            id: 'urn:book:2',
+          },
+        ],
+      })
+    );
+
+    let baseIds = this.store
+      .peekAll('com.example.bookstore.Book')
+      .map(x => x.id)
+      .sort();
+    assert.deepEqual(baseIds, ['urn:book:1', 'urn:book:2'], 'base records in cache');
+
+    let projectionIds = this.store
+      .peekAll('com.example.bookstore.BookProjection')
+      .map(x => x.id)
+      .sort();
+    assert.deepEqual(projectionIds, ['urn:book:1', 'urn:book:2'], 'projection records in cache');
+
+    let projectedBook = this.store.peekRecord('com.example.bookstore.BookProjection', 'urn:book:1');
+    assert.equal(
+      projectedBook.get('title'),
+      'A History of the English Speaking Peoples',
+      'projected attribute'
+    );
+    assert.equal(
+      projectedBook.get('otherBook.title'),
+      'The 30 Years War',
+      'projected reference attribute'
+    );
+    assert.equal(
+      projectedBook.get('otherBook._modelName'),
+      'com.example.bookstore.book-projection',
+      'projected reference can be projected record'
+    );
+
+    let baseBook = this.store.peekRecord('com.example.bookstore.Book', 'urn:book:1');
+    assert.equal(
+      baseBook.get('title'),
+      'A History of the English Speaking Peoples',
+      'base attribute'
+    );
+    assert.equal(baseBook.get('otherBook.title'), 'The 30 Years War', 'base reference attribute');
+    assert.equal(
+      baseBook.get('otherBook._modelName'),
+      'com.example.bookstore.book',
+      'base reference is a base record'
+    );
+  });
+});


### PR DESCRIPTION


Previously we would update the global cache each time we saw any type,
causing base & projection types to override each other in the order they
appeared.  This only affected the global cache so its only effect was
when resolving references.  In practice this didn't affect projection
types (since there you tend to resolve references by type and not rely
on the global cache) but it meant that referring to base types when any
projections were in the cache was impractical as you would easily get
projection types from references in base types.

[fix #122]