### PR TITLE
fix: trigger property change events

### DIFF
--- a/addon/record-array.js
+++ b/addon/record-array.js
@@ -45,6 +45,7 @@ export default class M3RecordArray extends EmberObject {
 
     deferArrayPropertyChange(this.store, this, 0, removeAmt, newRecords);
     deferPropertyChange(this.store, this, '[]');
+    deferPropertyChange(this.store, this, 'length');
     // eager change events on mutation as mutations are user entry points
     flushChanges(this.store);
   }
@@ -71,6 +72,12 @@ export default class M3RecordArray extends EmberObject {
   _removeInternalModels(internalModels) {
     if (this._resolved) {
       this._internalModels.removeObjects(internalModels);
+      deferArrayPropertyChange(this.store, this, 0, internalModels.length, 0);
+      deferPropertyChange(this.store, this, '[]');
+      deferPropertyChange(this.store, this, 'length');
+      // eager change events here; we're not processing payloads (that goes
+      // through `_setInternalModels`); we're doing `unloadRecord`
+      flushChanges(this.store);
     } else {
       for (let i = 0; i < internalModels.length; ++i) {
         let internalModel = internalModels[i];
@@ -96,6 +103,7 @@ export default class M3RecordArray extends EmberObject {
     if (triggerChange) {
       deferArrayPropertyChange(this.store, this, 0, originalLength, this._internalModels.length);
       deferPropertyChange(this.store, this, '[]');
+      deferPropertyChange(this.store, this, 'length');
     }
 
     this.setProperties({
@@ -114,6 +122,7 @@ export default class M3RecordArray extends EmberObject {
     this._internalModels = A();
     deferArrayPropertyChange(this.store, this, 0, originalLength, this._internalModels.length);
     deferPropertyChange(this.store, this, '[]');
+    deferPropertyChange(this.store, this, 'length');
   }
 
   _registerWithInternalModels(internalModels) {

--- a/tests/integration/reference-array-test.js
+++ b/tests/integration/reference-array-test.js
@@ -3,6 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 import DefaultSchema from 'ember-m3/services/m3-schema';
+import Component from '@ember/component';
+import { gt } from '@ember/object/computed';
 
 module('integration/reference-array', function(hooks) {
   setupRenderingTest(hooks);
@@ -75,6 +77,7 @@ module('integration/reference-array', function(hooks) {
     let books = bookstore.get('books');
     this.set('bookstore', bookstore);
     await render(hbs`
+      <span class='books-length'>{{this.bookstore.books.length}}</span>
       <ul>
       {{#each this.bookstore.books as |book|}}
         <li>Author: {{book.author.name}} </li>
@@ -85,15 +88,179 @@ module('integration/reference-array', function(hooks) {
     let renderedItems = this.element.querySelectorAll('ul li');
     assert.equal(renderedItems.length, 2, '2 initial authors');
 
+    let renderedLength = this.element.querySelector('.books-length').textContent;
+    assert.equal(renderedLength, '2', 'length === 2');
+
     books.popObject();
     await settled();
     renderedItems = this.element.querySelectorAll('ul li');
     assert.equal(renderedItems.length, 1, 'remove; re-render; now 1 author');
+
+    renderedLength = this.element.querySelector('.books-length').textContent;
+    assert.equal(renderedLength, '1', 'length rerenders');
 
     books.pushObject(this.store.peekRecord('com.example.Book', 'urn:book:3'));
     books.pushObject(this.store.peekRecord('com.example.Book', 'urn:book:3'));
     await settled();
     renderedItems = this.element.querySelectorAll('ul li');
     assert.equal(renderedItems.length, 3, 'add two more books; re-render; now 3 authors');
+
+    renderedLength = this.element.querySelector('.books-length').textContent;
+    assert.equal(renderedLength, '3', 'length rerenders again');
+  });
+
+  test('reference arrays trigger rerenders on unload', async function(assert) {
+    this.store.pushPayload('com.example.Bookstore', {
+      data: {
+        id: 'urn:bookstore:1',
+        type: 'com.example.Bookstore',
+        attributes: {
+          '*books': ['urn:book:1', 'urn:book:2'],
+        },
+      },
+      included: [
+        {
+          id: 'urn:book:1',
+          type: 'com.example.Book',
+          author: {
+            name: 'Edward Gibbons',
+          },
+        },
+        {
+          id: 'urn:book:2',
+          type: 'com.example.Book',
+          author: {
+            name: 'Winston Churchill',
+          },
+        },
+        {
+          id: 'urn:book:3',
+          type: 'com.example.Book',
+          attributes: {
+            author: {
+              name: 'George R. R. Martin',
+            },
+          },
+        },
+      ],
+    });
+
+    let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
+    let books = bookstore.get('books');
+    this.set('bookstore', bookstore);
+    await render(hbs`
+      <span class='books-length'>{{this.bookstore.books.length}}</span>
+      <ul>
+      {{#each this.bookstore.books as |book|}}
+        <li>Author: {{book.author.name}} </li>
+      {{/each}}
+      </ul>
+    `);
+
+    let renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 2, '2 initial authors');
+
+    let renderedLength = this.element.querySelector('.books-length').textContent;
+    assert.equal(renderedLength, '2', 'length === 2');
+
+    books.objectAt(0).unloadRecord();
+    await settled();
+
+    renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 1, '1 author unloaded');
+
+    renderedLength = this.element.querySelector('.books-length').textContent;
+    assert.equal(renderedLength, '1', 'length === 1');
+
+    books.objectAt(0).unloadRecord();
+    await settled();
+
+    renderedItems = this.element.querySelectorAll('ul li');
+    assert.equal(renderedItems.length, 0, 'all authors gone');
+
+    renderedLength = this.element.querySelector('.books-length').textContent;
+    assert.equal(renderedLength, '0', 'length === 0');
+  });
+
+  test('mutating reference arrays causes length cps to invalidate', async function(assert) {
+    this.store.pushPayload('com.example.Bookstore', {
+      data: {
+        id: 'urn:bookstore:1',
+        type: 'com.example.Bookstore',
+        attributes: {
+          // initially no books
+          '*books': [],
+        },
+      },
+      included: [
+        {
+          id: 'urn:book:1',
+          type: 'com.example.Book',
+          author: {
+            name: 'Edward Gibbons',
+          },
+        },
+        {
+          id: 'urn:book:2',
+          type: 'com.example.Book',
+          author: {
+            name: 'Winston Churchill',
+          },
+        },
+        {
+          id: 'urn:book:3',
+          type: 'com.example.Book',
+          attributes: {
+            author: {
+              name: 'George R. R. Martin',
+            },
+          },
+        },
+      ],
+    });
+
+    let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
+    let books = bookstore.get('books');
+    this.owner.register(
+      'component:x-foo',
+      Component.extend({
+        hasAnything: gt('bookstore.books.length', 0),
+      })
+    );
+    this.owner.register(
+      'template:components/x-foo',
+      hbs`
+        {{#if this.hasAnything}}
+          Has Content
+        {{else}}
+          Empty
+        {{/if}}
+    `
+    );
+
+    this.set('bookstore', bookstore);
+
+    assert.equal(books.length, 0, 'initial books.length');
+    await render(hbs`
+      {{x-foo bookstore=this.bookstore}}
+    `);
+
+    let text = this.element.textContent.trim();
+    assert.equal(text, 'Empty', 'initially length == 0');
+
+    this.store.pushPayload('com.example.Bookstore', {
+      data: {
+        id: 'urn:bookstore:1',
+        type: 'com.example.Bookstore',
+        attributes: {
+          '*books': ['urn:book:1', 'urn:book:2'],
+        },
+      },
+    });
+
+    await settled();
+    assert.equal(books.length, 2, 'updated books.length');
+    text = this.element.textContent.trim();
+    assert.equal(text, 'Has Content', 'length updated');
   });
 });


### PR DESCRIPTION
RecordArray now triggers change events on unloadRecord.  Previously we
relied on `ArrayProxy` to implicitly trigger change events during
`removeObjects`.

Also trigger change events for `length` which was similarly handled by
`ArrayProxy`.
