### PR TITLE
Remove --disable-gpu flag when starting headless chrome

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -9,7 +9,6 @@ module.exports = {
       mode: 'ci',
       args: [
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',


### PR DESCRIPTION
The `--disable-gpu` flag is [no longer necessary](https://bugs.chromium.org/p/chromium/issues/detail?id=737678) and, at least in some cases, is [causing issues](https://bugs.chromium.org/p/chromium/issues/detail?id=982977).

This flag has already been [removed from ember-cli's blueprints](https://github.com/ember-cli/ember-cli/pull/8774)

As you may already know, this project's test suite is run as part of [Ember Data](https://github.com/emberjs/data)'s test suite to help catch regressions.  The flag has already been [removed from Ember Data's own testem config](https://github.com/emberjs/data/pull/6298) but Ember Data's complete test suite cannot successfully run until all of our external integration partners have also removed this flag.