### PR TITLE
fix: base RecordData creation when creating a projection

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -4,7 +4,7 @@ import { assign, merge } from '@ember/polyfills';
 import { copy } from './utils/copy';
 import { assert } from '@ember/debug';
 import Ember from 'ember';
-import { IS_RECORD_DATA } from 'ember-compatibility-helpers';
+import { IS_RECORD_DATA, gte } from 'ember-compatibility-helpers';
 
 const emberAssign = assign || merge;
 
@@ -696,11 +696,15 @@ export default class M3RecordData {
       }
 
       if (IS_RECORD_DATA) {
-        this._baseRecordData = this.storeWrapper.recordDataFor(
-          dasherize(baseModelName),
-          this.id,
-          this.clientId
-        );
+        if (gte('ember-data', '3.13.0')) {
+          this._baseRecordData = this.storeWrapper.recordDataFor(dasherize(baseModelName), this.id);
+        } else {
+          this._baseRecordData = this.storeWrapper.recordDataFor(
+            dasherize(baseModelName),
+            this.id,
+            this.clientId
+          );
+        }
       } else {
         this._baseRecordData = this.storeWrapper.modelDataFor(
           dasherize(baseModelName),

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -540,11 +540,6 @@ module('unit/record-data', function(hooks) {
       baseRecordData._projections.find(x => x === projectionRecordData),
       'Expected projection recordData to have been registered'
     );
-    assert.equal(
-      baseRecordData.clientId,
-      projectionRecordData.clientId,
-      'Expected the base recordData to have the same clientId as the projection'
-    );
 
     // actually set to be saved
     projectionRecordData.setAttr('name', 'Harry Potter');


### PR DESCRIPTION
M3 was relying on an unknown implicit behavior to create new client side records without using createRecord. This broke when `clientId` began to be unique across types. This change prepares M3 for versions of EmberData where `clientId` is unique across types when paired with https://github.com/emberjs/data/pull/6334