### PR TITLE
fix: a couple of bugs with references

### DIFF
--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -12,19 +12,20 @@ import {
 } from './utils/resolve';
 
 function resolveReference(store, reference) {
+  let { id } = reference;
   if (reference.type === null) {
     // for schemas with a global id-space but multiple types, schemas may
     // report a type of null
-    let internalModel = store._globalM3Cache[reference.id];
+    let internalModel = store._globalM3Cache[id];
     return internalModel ? internalModel.getRecord() : null;
   } else {
     // respect the user schema's type if provided
-    return store.peekRecord(reference.type, reference.id);
+    return id !== null && id !== undefined ? store.peekRecord(reference.type, reference.id) : null;
   }
 }
 
 function resolveReferenceOrReferences(store, model, key, value, reference) {
-  if (Array.isArray(value) || Array.isArray(reference)) {
+  if (Array.isArray(reference)) {
     return resolveRecordArray(store, model, key, reference);
   }
 

--- a/tests/unit/model/references-test.js
+++ b/tests/unit/model/references-test.js
@@ -1,0 +1,59 @@
+import { test, module } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+
+module('unit/model/references-test', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    class TestSchema extends DefaultSchema {
+      includesModel() {
+        return true;
+      }
+
+      computeAttributeReference() {
+        return { id: null, type: 'com.example.Author' };
+      }
+    }
+    this.owner.register('service:m3-schema', TestSchema);
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('references with null ids return null records', function(assert) {
+    this.store.push({
+      data: {
+        id: 'urn:book:1',
+        type: 'com.example.Book',
+        attributes: {
+          author: null,
+        },
+      },
+    });
+
+    let book = this.store.peekRecord('com.example.Book', 'urn:book:1');
+    assert.equal(book.id, 'urn:book:1', 'book pushed into store');
+
+    assert.strictEqual(book.get('author'), null, 'reference with null id does not error');
+  });
+
+  test('references are prioritized over raw values for determining isArray', function(assert) {
+    this.store.push({
+      data: {
+        id: 'urn:book:1',
+        type: 'com.example.Book',
+        attributes: {
+          author: ['urn:author:1'],
+        },
+      },
+    });
+
+    let book = this.store.peekRecord('com.example.Book', 'urn:book:1');
+    assert.equal(book.id, 'urn:book:1', 'book pushed into store');
+
+    assert.strictEqual(
+      book.get('author'),
+      null,
+      'null reference with raw array value does not error'
+    );
+  });
+});


### PR DESCRIPTION
1. Allow user schemas to compute references with `null` ids and given
  types (which will result in `null` results)
2. Prioritize the user schema's `computeAttributeReference` over the raw
  value when deciding whether to build a reference array.