### PR TITLE
fix: enable .debugJSON to also work for projections

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -228,7 +228,7 @@ export default class MegamorphicModel extends EmberObject {
   }
 
   debugJSON() {
-    return recordDataFor(this)._data;
+    return recordDataFor(this)._debugJSON();
   }
 
   eachAttribute(callback, binding) {

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -796,6 +796,15 @@ export default class M3RecordData {
     );
   }
 
+  _debugJSON() {
+    // if the model is a projection, delegate to the base record to get the JSON
+    if (this._baseRecordData) {
+      return this._baseRecordData._debugJSON();
+    }
+
+    return this._data;
+  }
+
   _destroyChildRecordData(key) {
     if (this._baseRecordData) {
       return this._baseRecordData._destroyChildRecordData(key);

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -3131,4 +3131,42 @@ module('unit/model', function(hooks) {
       });
     });
   });
+
+  test('.debugJSON returns expected JSON for m3 records', function(assert) {
+    const BOOK_ID = 'isbn:9780439708180';
+    const BOOK_CLASS_PATH = 'com.example.bookstore.Book';
+    const expectedJSON = {
+      title: `Harry Potter and the Sorcerer's Stone`,
+      chapters: [
+        {
+          name: 'The Boy Who Lived',
+        },
+        {
+          name: 'The Vanishing Glass',
+        },
+      ],
+    };
+    run(() => {
+      this.store.push({
+        data: {
+          id: BOOK_ID,
+          type: BOOK_CLASS_PATH,
+          attributes: {
+            title: `Harry Potter and the Sorcerer's Stone`,
+            chapters: [
+              {
+                name: 'The Boy Who Lived',
+              },
+              {
+                name: 'The Vanishing Glass',
+              },
+            ],
+          },
+        },
+      });
+    });
+    const bookRecord = this.store.peekRecord(BOOK_CLASS_PATH, BOOK_ID);
+
+    assert.deepEqual(bookRecord.debugJSON(), expectedJSON, 'The JSON returned is correct');
+  });
 });

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -2816,6 +2816,33 @@ module('unit/projection', function(hooks) {
       );
     });
 
+    test('.debugJSON returns expected JSON for projections', function(assert) {
+      const expectedJSON = {
+        title: 'Alice in Wonderland',
+        author: {
+          name: 'Lewis Carol',
+        },
+      };
+
+      run(() => {
+        this.store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_EXCERPT_PROJECTION_CLASS_PATH,
+            attributes: {
+              title: BOOK_TITLE_1,
+              author: {
+                name: BOOK_AUTHOR_NAME_1,
+              },
+            },
+          },
+        });
+      });
+      const bookRecord = this.store.peekRecord(BOOK_EXCERPT_PROJECTION_CLASS_PATH, BOOK_ID);
+
+      assert.deepEqual(bookRecord.debugJSON(), expectedJSON, 'The JSON returned is correct');
+    });
+
     skip('update and save of a projection does not touch non-whitelisted properties', function(assert) {
       let updateRecordCalls = 0;
       this.owner.register(


### PR DESCRIPTION
This allows `.debugJSON` to work for both vanilla records and projections. Before `debugJSON` was too naive to handle projections which need to grab the JSON from the base record data.