### PR TITLE
fix: arrayDidChange called with correct args

### DIFF
--- a/addon/record-array.js
+++ b/addon/record-array.js
@@ -43,9 +43,10 @@ export default class M3RecordArray extends EmberObject {
     this._registerWithInternalModels(newInternalModels);
     this._resolved = true;
 
-    deferArrayPropertyChange(this.store, this, 0, removeAmt, newRecords);
+    deferArrayPropertyChange(this.store, this, idx, removeAmt, addAmt);
     deferPropertyChange(this.store, this, '[]');
     deferPropertyChange(this.store, this, 'length');
+
     // eager change events on mutation as mutations are user entry points
     flushChanges(this.store);
   }

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -4,4 +4,6 @@ import { start } from 'ember-qunit';
 import './helpers/watch-property';
 
 setResolver(resolver);
-start();
+start({
+  setupTestIsolationValidation: true,
+});

--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -33,10 +33,11 @@ module('unit/query-cache', function(hooks) {
 
     this.queryCache = this.store._queryCache;
     this.adapterAjax = this.sinon.stub(this.adapter, 'ajax').returns(resolve());
-  }),
-    hooks.afterEach(function() {
-      this.sinon.restore();
-    });
+  });
+
+  hooks.afterEach(function() {
+    this.sinon.restore();
+  });
 
   test('.queryURL uses adapter.ajax to send requests', function(assert) {
     assert.equal(this.adapterAjax.callCount, 0, 'initial callCount 0');
@@ -176,8 +177,8 @@ module('unit/query-cache', function(hooks) {
     this.adapterAjax.returns(
       resolve({
         data: {
-          id: 1,
-          type: 'my-type',
+          id: 123,
+          type: 'my-synthetic-type',
         },
       })
     );
@@ -194,7 +195,7 @@ module('unit/query-cache', function(hooks) {
   test('a custom -ember-m3 adapter can be registered', function(assert) {
     let payload = {
       data: {
-        id: 1,
+        id: 2,
         type: 'my-type',
       },
     };


### PR DESCRIPTION
Previously `replace` did not pass the index to array observers
correctly.

Also enable `setupTestIsolationValidation`.

Co-authored-by: Robert Jackson <rjackson@linkedin.com>