### PR TITLE
chore: Remove extra commitlint rules

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -1,14 +1,6 @@
 module.exports = {
   rules: {
     'body-leading-blank': [2, 'always'],
-    'footer-leading-blank': [2, 'always'],
     'header-max-length': [2, 'always', 72],
-    'scope-case': [2, 'always', 'lower-case'],
-    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
-    'subject-empty': [2, 'never'],
-    'subject-full-stop': [2, 'never', '.'],
-    'type-case': [2, 'always', 'lower-case'],
-    'type-empty': [2, 'never'],
-    'type-enum': [2, 'always', ['chore', 'docs', 'feat', 'fix', 'perf', 'refactor', 'test', 'dx']],
   },
 };


### PR DESCRIPTION
Most of the rules I don't actually like.  The only ones I really want to
enforce are the ones that are relevant to standard git tools and impact
the way eg `git log` formats messages.