### PR TITLE
fix: issues with dirty checking

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -431,7 +431,7 @@ export default class MegamorphicModel extends EmberObject {
     this._schema.setAttribute(this._modelName, attr, value, schemaInterface);
     schemaInterface._suppressNotifications = priorSuppressNotifications;
 
-    const isDirty = recordData.isAttrDirty(attr);
+    const isDirty = recordData.hasDirtyAttr();
 
     if (isDirty && !this.get('isDirty')) {
       this._updateCurrentState(updatedUncommitted);

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -623,7 +623,7 @@ export default class M3RecordData {
     if (this._baseRecordData) {
       return this._baseRecordData.isAttrDirty(...arguments);
     }
-    if (this._attributes[key] === undefined) {
+    if (!(key in this._attributes)) {
       return false;
     }
     let originalValue;
@@ -634,6 +634,18 @@ export default class M3RecordData {
     }
 
     return originalValue !== this._attributes[key];
+  }
+
+  hasDirtyAttr() {
+    if (this._baseRecordData) {
+      return this._baseRecordData.hasDirtyAttr();
+    }
+
+    if (this.__attributes === null) {
+      return false;
+    }
+
+    return Object.keys(this.__attributes).length > 0;
   }
 
   /**

--- a/tests/unit/model/dirty-test.js
+++ b/tests/unit/model/dirty-test.js
@@ -1,0 +1,49 @@
+import { test, module } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+
+module('unit/model/dirty', function(hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function() {
+    this.store = this.owner.lookup('service:store');
+
+    class TestSchema extends DefaultSchema {
+      includesModel(modelName) {
+        return /^com.example.bookstore\./i.test(modelName);
+      }
+      setAttribute(modelName, attr, value, schemaInterface) {
+        if (attr === 'name') {
+          schemaInterface.setAttr('title', value);
+        }
+      }
+    }
+    this.owner.register('service:m3-schema', TestSchema);
+
+    this.store.push({
+      data: {
+        id: 'urn:li:book:1',
+        type: 'com.example.bookstore.Book',
+        attributes: {
+          title: 'How to Win Friends and Influence People',
+        },
+      },
+    });
+  });
+
+  test('setAttribute dirties the model if any attribute changes', function(assert) {
+    let book = this.store.peekRecord('com.example.bookstore.Book', 'urn:li:book:1');
+
+    assert.equal(book.get('isDirty'), false, 'initially not dirty');
+    book.set('name', 'A History of the English Speaking Peoples Vol I');
+    assert.equal(book.get('isDirty'), true, 'dirty after set');
+  });
+
+  test('setAttribute does not dirty the model if no attribute changes', function(assert) {
+    let book = this.store.peekRecord('com.example.bookstore.Book', 'urn:li:book:1');
+
+    assert.equal(book.get('isDirty'), false, 'initially not dirty');
+    book.set('howmuchilikeit', 'a lot');
+    assert.equal(book.get('isDirty'), false, 'still not dirty after set');
+  });
+});

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -291,13 +291,15 @@ module('unit/record-data', function(hooks) {
     );
     const attrName = 'name';
 
-    assert.notOk(
+    assert.equal(
       projectedRecordData.isAttrDirty(attrName),
+      false,
       'Fake attribute is not dirty initially'
     );
     projectedRecordData.setAttr(attrName, 'The best store in town');
-    assert.ok(
+    assert.equal(
       projectedRecordData.isAttrDirty(attrName),
+      true,
       'Fake attribute is dirty after being mutated'
     );
   });


### PR DESCRIPTION
Previously `model.set(attr, val)` would only dirty if the schema dirtied
specifically `attr`.  Now, the model will be dirtied if the schema
dirties *any* attribute during a set.

Co-authored-by: Robert Jackson <me@rwjblue.com>