### PR TITLE
chore: update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
 
     # runs tests against future Ember versions
     - stage: advance warning tests
-    - env: EMBER_TRY_SCENARIO=canary-channel
+      env: EMBER_TRY_SCENARIO=canary-channel
     - env: NAME=floating dependencies # used only to make Travis UI show description
       install: yarn install --no-lockfile --non-interactive
       script: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,6 @@ stages:
 jobs:
   fail_fast: true
   allow_failures:
-    # We can't currently test against ember-data #beta or #canary due to
-    # packages work; for now leave these as allowed failures
-   - env: EMBER_TRY_SCENARIO=beta-channel
    - env: EMBER_TRY_SCENARIO=canary-channel
    - env: NAME=floating dependencies
 
@@ -48,14 +45,13 @@ jobs:
 
     # runs tests against each supported Ember version
     - stage: specific version tests
-      env: EMBER_TRY_SCENARIO=ember-lts-3.4
+      env: EMBER_TRY_SCENARIO=release-channel
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
     - env: EMBER_TRY_SCENARIO=ember-lts-3.8
-    - env: EMBER_TRY_SCENARIO=release-channel
-    - env: EMBER_TRY_SCENARIO=legacy-model-data
+    - env: EMBER_TRY_SCENARIO=beta-channel
 
     # runs tests against future Ember versions
     - stage: advance warning tests
-      env: EMBER_TRY_SCENARIO=beta-channel
     - env: EMBER_TRY_SCENARIO=canary-channel
     - env: NAME=floating dependencies # used only to make Travis UI show description
       install: yarn install --no-lockfile --non-interactive

--- a/README.md
+++ b/README.md
@@ -725,5 +725,14 @@ this.store.findRecord('com.example.bookstore.book', 1, { url: '/book/from/surpri
 
 ## Requirements
 
-- ember@^2.12.0
-- ember-data@~2.14.10
+ember-m3 supports three Ember.js and Ember Data versions
+
+- The [latest release](https://emberjs.com/releases/release/)
+- The current LTS version
+- The previous LTS version
+
+As of 23 September (ie when Ember 3.13.0 ships) this will mean
+
+- 3.13.x (the latest release)
+- 3.12.x (the current LTS)
+- 3.8.x (the previous LTS)

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -17,27 +17,20 @@ module.exports = function() {
           npm: {},
         },
         {
-          name: 'ember-lts-3.4',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.4.5',
-            },
-          },
-        },
-        {
           name: 'ember-lts-3.8',
           npm: {
             devDependencies: {
               'ember-source': '~3.8.0',
+              'ember-data': '~3.8.0',
             },
           },
         },
         {
-          name: 'legacy-model-data',
+          name: 'ember-lts-3.12',
           npm: {
             devDependencies: {
-              'ember-source': '~3.4.5',
-              'ember-data': '3.5.0-beta.2',
+              'ember-source': '~3.12.0',
+              'ember-data': '~3.12.0',
             },
           },
         },


### PR DESCRIPTION
- Fail the build on beta channel regressions
- Update README to clarify support policy now that we are less dependent
  on private Ember Data API