### PR TITLE
Add support for adapterOptions to queryURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ normalization to JSON API.
     was found, resolve the returned promise immediately with the cached entry
     and update the store when the request completes.
 
+  - `options.adapterOptions` defaults to `undefined`. The custom options to pass along to the `queryURL` function on the adapter.
+
 #### Caching
 
 When `cacheKey` is provided, the response is cached under `cacheKey`.

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -64,6 +64,7 @@ const STORE_OVERRIDES = {
    * @param {boolean} [options.reload=false] If true, issue a request even a cached value exists
    * @param {boolean} [options.backgroundReload=false] If true and a cached value exists,
    * issue a non-blocking request but immediately fulfill with the cached value
+   * @param {Object} [options.adapterOptions] The custom options to pass along to the `queryURL` function on the adapter
    * @returns {Promise<M3RecordData|RecordArray,Error>} Promise for loading `url` that fulfills to
    * an `M3RecordData` if the response is a single resource or a `RecordArray` of `M3RecordData`s
    * if the response is an array of resources

--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -29,12 +29,16 @@ export default class QueryCache {
       cacheKey = null,
       reload = false,
       backgroundReload = false,
+      adapterOptions = undefined,
     } = {},
     array
   ) {
     let options = {};
     if (params) {
       options.params = params;
+    }
+    if (adapterOptions) {
+      options.adapterOptions = adapterOptions;
     }
 
     let cachedPromise = cacheKey ? this._queryCache[cacheKey] : undefined;

--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -914,6 +914,32 @@ module('unit/query-cache', function(hooks) {
     });
   });
 
+  test('.queryURL passes adapterOptions to queryURL adapter hook if available', function(assert) {
+    let adapterOptions = { option: 'value' };
+
+    this.adapter.queryURL = this.sinon.stub().returns(
+      resolve({
+        data: {
+          id: '1',
+          type: 'something-or-other',
+          attributes: {},
+        },
+      })
+    );
+
+    let options = { adapterOptions };
+
+    this.adapter.namespace = 'ns';
+    return this.queryCache.queryURL('test-url', options).then(() => {
+      assert.deepEqual(
+        stubCalls(this.adapter.queryURL),
+        [[this.adapter + '', ['/ns/test-url', 'GET', { adapterOptions }]]],
+        'adapter.queryURL is called with adapterOptions'
+      );
+      assert.equal(this.adapterAjax.called, false, '`adapter.ajax` is not called');
+    });
+  });
+
   test('.cacheURL inserts consistently inserts a promise into cache', function(assert) {
     assert.expect(3);
     const mockResult = { id: 1, foo: 'bar' };


### PR DESCRIPTION
I've added support for `adapterOptions`, custom options that can be passed along to the adapter, to the `queryURL` method. This matches the behavior of other Ember Store methods, like the ones provided by the REST adapter.