### PR TITLE
Do not put mutable state on the prototype.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@
 module.exports = {
   name: 'ember-m3',
 
-  options: {
-    babel: {
-      loose: true,
-    },
+  init() {
+    this._super.init.apply(this, arguments);
+
+    this.options = this.options || {};
+    this.options.babel = this.options.babel || {};
+    this.options.babel.loose = true;
   },
 };


### PR DESCRIPTION
Using a mutable object on the addon's prototype causes issues when ember-m3 is consumed by an addon as a direct dependency.

The specific setup is:

* `ember-m3` depends on ember-compatibility-helpers
* `ember-m3` has the following in its `index.js`:

```js
module.exports = {
  name: require('./package').name,

  options: {
    m3: true,
    babel: {
      loose: true,
    },
  },
};
```

* addon B depends on `ember-m3` (**not** a dev dep)

In this scenario, `ember-m3` will be instantiated twice. Once for addon B's dummy app and again for addon B's direct dependency. Since `ember-m3` had a _mutable object_ on its prototype (yes, you know whats coming now) ember-compatibility-helpers adds a `plugins` array to it and pushes into it.

Now that ember-m3 has updated to Babel 7, pushing the same babel plugin into the plugins array twice triggers an error (which is super annoying to debug):

```
Build Error (broccoli-persistent-filter:Babel > [Babel: ember-m3]) in ember-m3/factory.js

Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]


Stack Trace and Error Report: /var/folders/mt/yt2qjpl93ls98lrkrs81rzch000pzv/T/error.dump.246a0987138182f85c209aed25484574.log
```