### PR TITLE
fix: inject store service

### DIFF
--- a/addon/adapters/debug-adapter.js
+++ b/addon/adapters/debug-adapter.js
@@ -285,4 +285,5 @@ export default class DebugAdapter extends DataAdapter {
   }
 }
 
+defineProperty(DebugAdapter.prototype, 'store', inject('store'));
 defineProperty(DebugAdapter.prototype, 'schema', inject('m3-schema'));


### PR DESCRIPTION
don't rely on EmberData's injection of store into data-adapter:main