### PR TITLE
Add headers support for queryURL

### DIFF
--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -126,6 +126,9 @@ export default class QueryCache {
     if (options.params) {
       ajaxOptions.data = options.params;
     }
+    if (options.adapterOptions && options.adapterOptions.headers) {
+      ajaxOptions.headers = options.adapterOptions.headers;
+    }
     return adapter.ajax(url, method, ajaxOptions);
   }
 


### PR DESCRIPTION
According to the m3 docs, it looks like currently in order to set custom headers, we have to reference the -ember-m3 adapter directly, it would be nice if we are able to pass the headers through store.queryURL so we can still take advantage of the serializer in queryURL: https://github.com/hjdivad/ember-m3#serializer--adapter

This change allows custom headers to be passed into queryURL. @runspired @hjdivad 