### PR TITLE
chore: cleanup deprecations

### DIFF
--- a/addon/adapters/interop-debug-adapter.js
+++ b/addon/adapters/interop-debug-adapter.js
@@ -21,8 +21,6 @@ if (has('@ember-data/debug')) {
 */
 
 export default class InteropDebugAdapter extends DebugAdapter {
-  @inject('store') store;
-
   init() {
     super.init(...arguments);
     const store = get(this, 'store');
@@ -100,3 +98,4 @@ function interceptDataTypes(schema, method) {
 }
 
 defineProperty(InteropDebugAdapter.prototype, 'schema', inject('m3-schema'));
+defineProperty(InteropDebugAdapter.prototype, 'store', inject('store'));

--- a/addon/adapters/interop-debug-adapter.js
+++ b/addon/adapters/interop-debug-adapter.js
@@ -3,6 +3,7 @@ import { get, defineProperty } from '@ember/object';
 import { inject } from '@ember/service';
 import { default as MegamorphicModel } from '../model';
 import require, { has } from 'require';
+import { run } from '@ember/runloop';
 
 let DebugAdapter;
 if (has('@ember-data/debug')) {
@@ -79,6 +80,11 @@ export default class InteropDebugAdapter extends DebugAdapter {
       releaseSuper();
       releaseM3();
     };
+  }
+
+  destroy() {
+    run(this._m3DebugAdapter, 'destroy');
+    super.destroy(...arguments);
   }
 }
 

--- a/addon/adapters/interop-debug-adapter.js
+++ b/addon/adapters/interop-debug-adapter.js
@@ -21,6 +21,8 @@ if (has('@ember-data/debug')) {
 */
 
 export default class InteropDebugAdapter extends DebugAdapter {
+  @inject('store') store;
+
   init() {
     super.init(...arguments);
     const store = get(this, 'store');

--- a/addon/adapters/m3-debug-adapter.js
+++ b/addon/adapters/m3-debug-adapter.js
@@ -16,7 +16,7 @@ import { default as MegamorphicModel } from '../model';
 // and getRecordKeywords (for search)
 export default class M3DebugAdapter extends DataAdapter {
   init(options = {}) {
-    super.init(options, ...arguments);
+    super.init(options);
     // This keeps track of all model types the debug adapter has seen already (so we don't watch for changes twice)
     this.seenTypesInAdapter = new Set();
     // This is the same attribute limit value that is set in Ember Inspector

--- a/addon/adapters/m3-debug-adapter.js
+++ b/addon/adapters/m3-debug-adapter.js
@@ -1,7 +1,7 @@
 import { A, isArray } from '@ember/array';
 import DataAdapter from '@ember/debug/data-adapter';
 import { get } from '@ember/object';
-import { inject } from '@ember/service';
+import { inject, defineProperty } from '@ember/service';
 import seenTypesPerStore from '../utils/seen-types-per-store';
 import { default as MegamorphicModel } from '../model';
 
@@ -16,8 +16,6 @@ import { default as MegamorphicModel } from '../model';
 // TODO: implement getFilters/getRecordColor/getRecordFilterValues (for record state in the cache)
 // and getRecordKeywords (for search)
 export default class M3DebugAdapter extends DataAdapter {
-  @inject('store') store;
-
   init(options = {}) {
     super.init(options);
     // This keeps track of all model types the debug adapter has seen already (so we don't watch for changes twice)
@@ -285,3 +283,5 @@ export default class M3DebugAdapter extends DataAdapter {
     return release;
   }
 }
+
+defineProperty(M3DebugAdapter.prototype, 'store', inject('store'));

--- a/addon/adapters/m3-debug-adapter.js
+++ b/addon/adapters/m3-debug-adapter.js
@@ -1,6 +1,7 @@
 import { A, isArray } from '@ember/array';
 import DataAdapter from '@ember/debug/data-adapter';
 import { get } from '@ember/object';
+import { inject } from '@ember/service';
 import seenTypesPerStore from '../utils/seen-types-per-store';
 import { default as MegamorphicModel } from '../model';
 
@@ -15,6 +16,8 @@ import { default as MegamorphicModel } from '../model';
 // TODO: implement getFilters/getRecordColor/getRecordFilterValues (for record state in the cache)
 // and getRecordKeywords (for search)
 export default class M3DebugAdapter extends DataAdapter {
+  @inject('store') store;
+
   init(options = {}) {
     super.init(options);
     // This keeps track of all model types the debug adapter has seen already (so we don't watch for changes twice)

--- a/addon/adapters/m3-debug-adapter.js
+++ b/addon/adapters/m3-debug-adapter.js
@@ -1,7 +1,7 @@
 import { A, isArray } from '@ember/array';
 import DataAdapter from '@ember/debug/data-adapter';
-import { get } from '@ember/object';
-import { inject, defineProperty } from '@ember/service';
+import { get, defineProperty } from '@ember/object';
+import { inject } from '@ember/service';
 import seenTypesPerStore from '../utils/seen-types-per-store';
 import { default as MegamorphicModel } from '../model';
 

--- a/tests/acceptance/m3-test.js
+++ b/tests/acceptance/m3-test.js
@@ -1,15 +1,16 @@
-import { test } from 'qunit';
-import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 import IndexPage from '../pages/index';
+import { click, currentURL } from '@ember/test-helpers';
 
-moduleForAcceptance('acceptance/m3');
+module('acceptance/m3', function(hooks) {
+  setupTest(hooks);
 
-test('payloads can be rendered as m3 models', function(assert) {
-  const page = new IndexPage();
+  test('payloads can be rendered as m3 models', async function(assert) {
+    const page = new IndexPage();
 
-  page.visit();
+    await page.visit();
 
-  andThen(() => {
     assert.equal(currentURL(), '/', 'navigated to right page');
 
     assert.deepEqual(
@@ -36,22 +37,18 @@ test('payloads can be rendered as m3 models', function(assert) {
       'able to read embedded arrays through reference arrays'
     );
   });
-});
 
-test('m3 models can be updated', function(assert) {
-  const page = new IndexPage();
+  test('m3 models can be updated', async function(assert) {
+    const page = new IndexPage();
 
-  page.visit();
+    await page.visit();
 
-  andThen(() => {
     assert.equal(currentURL(), '/', 'navigated to right page');
 
     assert.equal(page.books()[0].name(), 'The Birth of Britain');
-  });
 
-  click('button.update-data');
+    await click('button.update-data');
 
-  andThen(() => {
     assert.equal(page.books()[0].name(), 'Vol I. The Birth of Britain');
   });
 });

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+    ENV.APP.autoboot = false;
   }
 
   // if (environment === 'production') {

--- a/tests/integration/interop-debug-adapter-test.js
+++ b/tests/integration/interop-debug-adapter-test.js
@@ -222,34 +222,36 @@ module('integration/interop-debug-adapter', function(hooks) {
       typesAddedCallCount++;
       switch (typesAddedCallCount) {
         case 1:
+          // triggered due pushPayload in beforeEach
           return assert.deepEqual(
             typesToSend,
             m3TypesAdded,
-            'Correct type object passed into typesAdded initially for m3 record types'
+            'Added Case 1: Correct type object passed into typesAdded initially for m3 record types'
           );
         case 2:
+          // triggered due to push in beforeEach
           return assert.deepEqual(
             typesToSend,
             HasDebugAdapterPackage ? dsTypesAdded1 : dsTypesAdded1.concat(dsTypesAdded2),
-            'Correct type object passed into typesAdded for DS.Model record types'
+            'Added Case 2: Correct type object passed into typesAdded for DS.Model record types'
           );
         case 3:
+          return assert.deepEqual(
+            typesToSend,
+            newM3TypesAdded,
+            'Added Case 3: Correct type object passed into typesAdded for new m3 record types'
+          );
+        case 4:
           if (HasDebugAdapterPackage) {
             return assert.deepEqual(
               typesToSend,
               dsTypesAdded2,
-              'Correct type object passed into typesAdded for DS.Model record types'
+              'Added Case 4: Correct type object passed into typesAdded for DS.Model record types'
             );
           } else {
-            // fall through to case 4
+            // eslint-disable-next-line no-fallthrough
           }
-        // eslint-disable-next-line no-fallthrough
-        case 4:
-          return assert.deepEqual(
-            typesToSend,
-            newM3TypesAdded,
-            'Correct type object passed into typesAdded for new m3 record types'
-          );
+
         default:
           throw new Error(`Unexpected typesAdded call`);
       }
@@ -262,19 +264,19 @@ module('integration/interop-debug-adapter', function(hooks) {
           return assert.deepEqual(
             updatedTypesToSend,
             newDSTypesUpdated,
-            'Correct type object passed into typesUpdated when new DS.Model records are added'
+            'Update Case 1: Correct type object passed into typesUpdated when new DS.Model records are added'
           );
         case 2:
           return assert.deepEqual(
             updatedTypesToSend,
             m3TypesUpdated,
-            'Correct type object passed into typesUpdated initially for m3 record types'
+            'Update Case 2: Correct type object passed into typesUpdated initially for m3 record types'
           );
         case 3:
           return assert.deepEqual(
             updatedTypesToSend,
             newM3TypesUpdated,
-            'Correct type object passed into typesUpdated for new m3 record types'
+            'Update Case 3: Correct type object passed into typesUpdated for new m3 record types'
           );
         default:
           throw new Error(`Unexpected typesUpdated call`);
@@ -283,9 +285,11 @@ module('integration/interop-debug-adapter', function(hooks) {
 
     this.interopDebugAdapter.watchModelTypes(typesAdded, typesUpdated);
 
+    // typesAdded case 3
     this.store.pushPayload(NEW_MODEL_TYPE, NEW_MODEL_DATA);
     await settled();
 
+    // typesUpdated case 1 & typesAdded case 4
     this.store.push({
       data: {
         id: 'urn:genre:1',
@@ -296,8 +300,10 @@ module('integration/interop-debug-adapter', function(hooks) {
         },
       },
     });
+
     await settled();
 
+    // typesUpdated case 2
     this.store.pushPayload(BOOK_MODEL_TYPE, {
       data: {
         id: 'urn:bookstore:2',
@@ -313,6 +319,7 @@ module('integration/interop-debug-adapter', function(hooks) {
     });
     await settled();
 
+    // types updated case 3
     this.store.unloadAll(NEW_MODEL_TYPE);
     await settled();
   });

--- a/tests/integration/interop-debug-adapter-test.js
+++ b/tests/integration/interop-debug-adapter-test.js
@@ -249,9 +249,10 @@ module('integration/interop-debug-adapter', function(hooks) {
               'Added Case 4: Correct type object passed into typesAdded for DS.Model record types'
             );
           } else {
-            // eslint-disable-next-line no-fallthrough
+            // pre-the debug package EmberData would add all types by scanning for models/ so we
+            // would never add this type
           }
-
+        // eslint-disable-next-line no-fallthrough
         default:
           throw new Error(`Unexpected typesAdded call`);
       }

--- a/tests/integration/m3-debug-adapter-test.js
+++ b/tests/integration/m3-debug-adapter-test.js
@@ -34,13 +34,10 @@ module('integration/m3-debug-adapter', function(hooks) {
         }
       }
     );
+    this.owner.register('data-adapter:main', M3DebugAdapter);
     this.schema = this.owner.lookup('service:m3-schema');
     this.store = this.owner.lookup('service:store');
-
-    this._m3debugAdapter = M3DebugAdapter.create({
-      store: this.store,
-      schema: this.schema,
-    });
+    this._m3debugAdapter = this.owner.lookup('data-adapter:main');
 
     this.wrappedModelTypeObject = {
       name: BOOK_MODEL_TYPE,

--- a/tests/pages/index.js
+++ b/tests/pages/index.js
@@ -1,3 +1,5 @@
+import { visit } from '@ember/test-helpers';
+
 class PageObject {
   constructor({ scope }) {
     this.scope = scope;
@@ -66,7 +68,7 @@ export default class IndexPage extends PageObject {
   }
 
   visit() {
-    visit('/');
+    return visit('/');
   }
 
   books() {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,5 +1,6 @@
-import resolver from './helpers/resolver';
-import { setResolver } from '@ember/test-helpers';
+import Application from '../app';
+import { setApplication } from '@ember/test-helpers';
+import config from '../config/environment';
 import { start } from 'ember-qunit';
 import './helpers/watch-property';
 import QUnit from 'qunit';
@@ -9,7 +10,7 @@ QUnit.config.urlConfig.push({
   label: 'Enable Opt Features',
 });
 
-setResolver(resolver);
+setApplication(Application.create(config.APP));
 start({
   setupTestIsolationValidation: true,
 });


### PR DESCRIPTION
Resolves two deprecations that were spewing in the test suite:

1) deprecated test syntax
2) calling store methods after the store has been destroyed

For this latter I discovered we had tests leaking state across other tests, I've updated the test dependent on the leaked state to test a bit closer to what it *thought* it was testing.