### PR TITLE
fix: remove seen model types in debug-adapter when inspector is closed

### DIFF
--- a/addon/adapters/m3-debug-adapter.js
+++ b/addon/adapters/m3-debug-adapter.js
@@ -278,6 +278,9 @@ export default class M3DebugAdapter extends DataAdapter {
     let release = () => {
       this.localReleaseMethods.forEach(fn => fn());
       this.releaseMethods.removeObject(release);
+
+      // Clear out the model types in seenTypesInAdapter so they can be added again if the inspector is re-opened
+      this.seenTypesInAdapter.clear();
     };
     this.releaseMethods.pushObject(release);
     return release;

--- a/tests/integration/interop-debug-adapter-test.js
+++ b/tests/integration/interop-debug-adapter-test.js
@@ -396,4 +396,24 @@ module('integration/interop-debug-adapter', function(hooks) {
       },
     });
   });
+
+  test('watchModelTypes keeps track of modelTypes and clears them out on release', async function(assert) {
+    const releaseMethod = this.interopDebugAdapter.watchModelTypes(
+      () => {},
+      () => {}
+    );
+    assert.deepEqual(
+      this.interopDebugAdapter._m3DebugAdapter.seenTypesInAdapter,
+      new Set(['com.example.bookstore.book']),
+      'seenTypesInAdapter is populated in the m3 debug adapter'
+    );
+
+    await releaseMethod();
+
+    assert.deepEqual(
+      this.interopDebugAdapter._m3DebugAdapter.seenTypesInAdapter,
+      new Set(),
+      'seenTypesInAdapter is cleared out in the m3 debug adapter when the release method is called'
+    );
+  });
 });


### PR DESCRIPTION
This fix is similar to this PR in Ember Data: https://github.com/emberjs/data/pull/6549 which ensures that when the inspector is closed and reopened, the adapter correctly rewatches previously added model types.