### PR TITLE
Fix CUSTOM_MODEL_CLASS fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,14 +23,14 @@ function debugMacros(features) {
 module.exports = {
   name: 'ember-m3',
 
-  init() {
-    this._super.init.apply(this, arguments);
+  included() {
+    this._super.included.apply(this, arguments);
 
     let features;
     try {
       features = this.project.require('@ember-data/private-build-infra/src/features')();
     } catch (e) {
-      features = { CUSTOM_MODEL_CLASS: false };
+      features = { CUSTOM_MODEL_CLASS: this.isDevelopingAddon() ? null : false };
     }
 
     this.options = this.options || {};


### PR DESCRIPTION
We fell back to a value of `false` which would always strip the code.
This commit changes the fallback to `null` when developing the addon,
which leaves the feature flag a runtime concern.

Also move init code to `included` as `isDevelopingAddon()` is not
reliable in `init`.

Co-authored-by: Robert Jackson <me@rwjblue.com>