### PR TITLE
Fix dirty issue

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -683,6 +683,21 @@ export class EmbeddedMegamorphicModel extends MegamorphicModel {
     );
   }
 
+  _updateCurrentState(state) {
+    if (state === loadedSaved) {
+      let topRecordData = recordDataFor(this._topModel);
+      if (topRecordData.hasDirtyAttr()) {
+        // Nested models maintain state with their parents; this makes sense
+        // until we let people save nested models independently.  However, it
+        // means that nested models should not reset their parents to "not
+        // dirty" when their last changed attribute is set to its original
+        // value, if their parent has some other dirty attribute
+        return;
+      }
+    }
+    return super._updateCurrentState(state);
+  }
+
   // no special behaviour for ids of embedded/nested models
   get id() {
     return this.unknownProperty('id');

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -124,5 +124,20 @@ module('unit/model/state', function(hooks) {
 
     assert.equal(record.get('isDirty'), true, 'record shares state with nested record');
     assert.equal(record.get('rating.isDirty'), true, 'nested record dirty');
+
+    record.rollbackAttributes();
+
+    record.set('name', 'The Winds of Never Published');
+    assert.equal(record.get('isDirty'), true, 'record is dirty from outside nested record');
+
+    record.set('rating.avg', 11);
+    assert.equal(record.get('rating.isDirty'), true, 'nested record dirty from its own attr');
+
+    record.set('rating.avg', 10);
+    assert.equal(
+      record.get('isDirty'),
+      true,
+      'record is not un-dirtied from resetting nested value'
+    );
   });
 });


### PR DESCRIPTION
Nested models that have their last changed attribute set to its original
value should not undirty their parents, if those parents have other
dirty attributes.