### PR TITLE
Fix isDirty check for parents of nested models

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -475,7 +475,7 @@ export default class MegamorphicModel extends EmberObject {
     this._schema.setAttribute(this._modelName, attr, value, schemaInterface);
     schemaInterface._suppressNotifications = priorSuppressNotifications;
 
-    const hasDirtyAttr = recordData.hasDirtyAttr();
+    const hasDirtyAttr = recordData.hasChangedAttributes();
     const isDirty = get(this, 'isDirty');
 
     if (hasDirtyAttr && !isDirty) {
@@ -686,7 +686,7 @@ export class EmbeddedMegamorphicModel extends MegamorphicModel {
   _updateCurrentState(state) {
     if (state === loadedSaved) {
       let topRecordData = recordDataFor(this._topModel);
-      if (topRecordData.hasDirtyAttr()) {
+      if (topRecordData.hasChangedAttributes()) {
         // Nested models maintain state with their parents; this makes sense
         // until we let people save nested models independently.  However, it
         // means that nested models should not reset their parents to "not

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -739,18 +739,6 @@ export default class M3RecordData {
     return originalValue !== this._attributes[key];
   }
 
-  hasDirtyAttr() {
-    if (this._baseRecordData) {
-      return this._baseRecordData.hasDirtyAttr();
-    }
-
-    if (this.__attributes === null) {
-      return false;
-    }
-
-    return Object.keys(this.__attributes).length > 0;
-  }
-
   /**
    * @readonly
    * @returns {Object}

--- a/tests/unit/model/projections/changed-attrs-test.js
+++ b/tests/unit/model/projections/changed-attrs-test.js
@@ -94,6 +94,43 @@ module('unit/model/projections/changed-attrs', function(hooks) {
     );
   });
 
+  test('resetting a property on parent model while nested model is dirty keeps parent model dirty', function(assert) {
+    this.store.push({
+      data: [
+        {
+          id: 'urn:book:1',
+          type: 'com.bookstore.Book',
+          attributes: {
+            title: 'A History of the English Speaking Peoples Vol I',
+            randomChapter: {
+              position: 2,
+              title: 'Not actually a chapter in this book',
+            },
+          },
+        },
+      ],
+    });
+
+    let record = this.store.peekRecord('com.bookstore.Book', 'urn:book:1');
+
+    assert.equal(
+      record.get('randomChapter.title'),
+      'Not actually a chapter in this book',
+      'read randomChapter.title (nested record)'
+    );
+
+    record.set('title', 'something');
+    record.get('randomChapter').set('position', 3);
+    record.set('title', 'A History of the English Speaking Peoples Vol I');
+    assert.equal(record.get('isDirty'), true, 'record is still dirty');
+    record.get('randomChapter').set('position', 2);
+    assert.equal(
+      record.get('isDirty'),
+      false,
+      'record is not dirty after nested record becomes clean'
+    );
+  });
+
   test('Can set a many embedded property to a semi resolved array containing a mix of pojos and megamorphic models - projections', async function(assert) {
     assert.expect(4);
     this.owner.register(


### PR DESCRIPTION
https://github.com/hjdivad/ember-m3/pull/377 introduced `hasDirtyAttr()` in order to have better support for state updating when a record has an attribute set.

https://github.com/hjdivad/ember-m3/pull/433 used `hasDirtyAttr()` to check whether to revert the record to a clean state.

However, `hasDirtyAttr` did not account for nestedModels, thus reverting the parentModel to a clean state even when nestedModels had changes.

This commit removves `hasDirtyAttr` and replaces it with existing method `hasChangedAttributes` which already correctly accounts for the childRecordDatas.