### PR TITLE
Allow .toString to be called on record prototype

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -609,6 +609,12 @@ export default class MegamorphicModel extends EmberObject {
   }
 
   toString() {
+    // Check needed for Ember Inspector support:
+    // https://github.com/emberjs/ember-inspector/blob/545e3c1c7a47f7a033025037f6f1e8d1d4c60624/ember_debug/object-inspector.js#L622
+    if (this === this.constructor.prototype) {
+      return 'MegamorphicModel';
+    }
+
     return `<MegamorphicModel:${this.id}>`;
   }
 

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -3201,4 +3201,21 @@ module('unit/m3-model', function(hooks) {
 
     assert.deepEqual(bookRecord.debugJSON(), expectedJSON, 'The JSON returned is correct');
   });
+
+  test('Calling .toString on the record prototype correctly returns MegamorphicModel', function(assert) {
+    let model = run(() =>
+      this.store.push({
+        data: {
+          id: 'isbn:9780439708180',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: `Harry Potter and the Sorcerer's Stone`,
+          },
+        },
+        included: [],
+      })
+    );
+
+    assert.equal(Object.getPrototypeOf(model).toString(), 'MegamorphicModel');
+  });
 });


### PR DESCRIPTION
The inspector error is no longer thrown when you click on a record.

<img width="312" alt="Screen Shot 2020-01-27 at 8 34 18 PM" src="https://user-images.githubusercontent.com/10149117/73235882-0b847380-4145-11ea-964e-eff73b1e0372.png">

I'm not that sure if the test setup is ideal though, so would like feedback on that. I also tried to stub out `init` as a no-op, but then I got a `Maximum call stack size exceeded` error as it bounced between getting the `id` and `unknownProperty.` Is there actually I way I can test before `init` is run?