### PR TITLE
Fix nightly run

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,8 @@ name: Nightly
 
 on:
   schedule:
-    - cron: '* 14 * * *' # 1400 UTC / 0600 PT
+    # minute hour day-of-month month day-of-week
+    - cron: '0 14 * * *' # 1400 UTC / 0600 PT
 
 jobs:
   test-floating-deps:


### PR DESCRIPTION
cron * 14 means every minute of the 14th hour.  GitHub Actions will
limit this to the minimum of every 5 minutes, although it didn't
actually run 12 times presumably because of the length of the jobs
themselves.

Fix the cron schedule so the job only runs once per night.