### PR TITLE
Increase browser start timeout

### DIFF
--- a/testem.js
+++ b/testem.js
@@ -4,6 +4,7 @@ module.exports = {
   disable_watching: true,
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
+  browser_start_timeout: 120,
   browser_args: {
     Chrome: {
       mode: 'ci',


### PR DESCRIPTION
Some CI systems seem to hit the default limit much more often than others. Specifically, GitHub actions seems to fail fairly consistently (5 out of 10 job runs) without increasing the timeout, but passes consistently with an increased limit.

This matches the change made in the default blueprint https://github.com/ember-cli/ember-cli/pull/8986