### PR TITLE
Fix memory leak in fastboot caused by modifying class prototype

### DIFF
--- a/addon/mixins/store.js
+++ b/addon/mixins/store.js
@@ -21,6 +21,8 @@ export const recordDataToRecordMap = new WeakMap();
 export const recordDataToQueryCache = new WeakMap();
 export const recordToRecordArrayMap = new WeakMap();
 
+let hasModifiedStorePrototype = false;
+
 class SchemaDefinition {
   constructor(store, dsModelSchema) {
     this.store = store;
@@ -213,8 +215,7 @@ const StoreMixin = {
       }
 
       if (GTE_VERSION_3_12) {
-        if (this._modifiedInternalModelMapProto === undefined) {
-          let store = this;
+        if (!hasModifiedStorePrototype && this._modifiedInternalModelMapProto === undefined) {
           // set this up for removals
           let proto = (this._modifiedInternalModelMapProto = Object.getPrototypeOf(
             this._internalModelsFor(self.modelName)
@@ -223,10 +224,11 @@ const StoreMixin = {
           let originalRemove = proto.remove;
           proto.__originalRemove = originalRemove;
           proto.remove = function remove(internalModel) {
-            delete store._globalM3Cache[internalModel.id];
+            delete internalModel.store._globalM3Cache[internalModel.id];
             return originalRemove.apply(this, arguments);
           };
           this._internalModelMapModified = true;
+          hasModifiedStorePrototype = true;
         }
       }
 
@@ -240,6 +242,7 @@ const StoreMixin = {
         let proto = this._modifiedInternalModelMapProto;
         proto.remove = proto.__originalRemove;
         this._modifiedInternalModelMapProto = undefined;
+        hasModifiedStorePrototype = false;
       }
     }
     return this._super();


### PR DESCRIPTION
When there are multiple requests in parallel in fastboot, using an instance level check for guarding the proto modifications does not work, as each instance of the store will modify the globally shared class prototype, and stash the previously modified one. The stashed methods end up creating a chain leading to a memory leak. 