### PR TITLE
Dropping support for < ember-data 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        try-scenario: [release-channel, release-n-1, ember-lts-3.16, ember-lts-3.12, ember-lts-3.8, ember-data-packages-latest]
+        try-scenario: [release-channel, release-n-1, ember-lts, ember-lts-n-1, ember-data-packages-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -743,11 +743,11 @@ ember-m3 supports three Ember.js and Ember Data versions
 - The current LTS version
 - The previous LTS version
 
-As of 12 December this means:
+As of 30 April this means:
 
-- 3.15.x (the latest release)
-- 3.14.x (the previous release)
-- 3.12.x (the current LTS)
-- 3.8.x (the previous LTS)
+- 3.18.x (the latest release)
+- 3.17.x (the previous release)
+- 3.16.x (the current LTS)
+- 3.12.x (the previous LTS)
 
 On the build side, a [supported version of node](https://nodejs.org/en/about/releases/) is required.

--- a/addon/-infra/potential-packages.js
+++ b/addon/-infra/potential-packages.js
@@ -10,7 +10,6 @@
 */
 export default {
   HAS_EMBER_DATA_PACKAGE: 'ember-data',
-  HAS_STORE_PACKAGE: '@ember-data/store',
   HAS_MODEL_PACKAGE: '@ember-data/model',
   HAS_RECORD_DATA_PACKAGE: '@ember-data/record-data',
   HAS_ADAPTER_PACKAGE: '@ember-data/adapter',

--- a/addon/-infra/versions.js
+++ b/addon/-infra/versions.js
@@ -10,8 +10,5 @@
   The file itself is stripped from production builds.
 */
 export default {
-  GTE_VERSION_3_12: true,
-  GTE_VERSION_3_5_1: true,
   GTE_VERSION_3_13: true,
-  IS_RECORD_DATA: true,
 };

--- a/addon/-private.js
+++ b/addon/-private.js
@@ -1,4 +1,3 @@
-import { IS_RECORD_DATA } from 'ember-m3/-infra/versions';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 
 export function recordDataFor(recordOrInternalModel) {
@@ -6,9 +5,6 @@ export function recordDataFor(recordOrInternalModel) {
     return recordOrInternalModel._recordData;
   }
   let internalModel = recordOrInternalModel._internalModel || recordOrInternalModel;
-  if (!IS_RECORD_DATA) {
-    return internalModel._modelData;
-  }
 
   return internalModel._recordData;
 }

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -1,5 +1,4 @@
 import '../mixins/store';
-import { HAS_EMBER_DATA_PACKAGE } from 'ember-m3/-infra/packages';
 import { DEBUG } from '@glimmer/env';
 import require from 'require';
 
@@ -20,10 +19,13 @@ function initializeDebugAdapter(registry) {
 }
 
 export function initialize(application) {
-  if (!HAS_EMBER_DATA_PACKAGE) {
-    application.inject('route', 'store', 'service:store');
-    application.inject('controller', 'store', 'service:store');
-  }
+  // This should be unnecessary
+  // it is done by the meta package
+  // but it should be done by the store package
+  // https://github.com/emberjs/data/issues/7158
+  application.inject('route', 'store', 'service:store');
+  application.inject('controller', 'store', 'service:store');
+
   initializeDebugAdapter(application);
 }
 

--- a/addon/m3-tracked-array.js
+++ b/addon/m3-tracked-array.js
@@ -7,14 +7,8 @@ import { recordDataFor } from './-private';
 import { deprecate } from '@ember/debug';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 import MegamorphicModel from './model';
-import require from 'require';
 import { recordDataToRecordMap } from './mixins/store';
-import { HAS_STORE_PACKAGE } from 'ember-m3/-infra/packages';
-
-let recordIdentifierFor;
-if (HAS_STORE_PACKAGE) {
-  recordIdentifierFor = require('@ember-data/store').recordIdentifierFor;
-}
+import { recordIdentifierFor } from '@ember-data/store';
 
 /**
  * M3TrackedArray

--- a/addon/record-array.js
+++ b/addon/record-array.js
@@ -11,14 +11,8 @@ import {
   flushChanges,
 } from './utils/notify-changes';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
-import { HAS_STORE_PACKAGE } from 'ember-m3/-infra/packages';
 import { recordDataToRecordMap, recordToRecordArrayMap } from './mixins/store';
-import require from 'require';
-
-let recordIdentifierFor;
-if (HAS_STORE_PACKAGE) {
-  recordIdentifierFor = require('@ember-data/store').recordIdentifierFor;
-}
+import { recordIdentifierFor } from '@ember-data/store';
 
 /**
  * M3RecordArray

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -6,7 +6,7 @@ import { assert } from '@ember/debug';
 import Ember from 'ember';
 import { recordDataToRecordMap, recordDataToQueryCache } from './mixins/store';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
-import { GTE_VERSION_3_13, IS_RECORD_DATA } from 'ember-m3/-infra/versions';
+import { GTE_VERSION_3_13 } from 'ember-m3/-infra/versions';
 
 const emberAssign = assign || merge;
 
@@ -798,18 +798,11 @@ export default class M3RecordData {
         return;
       }
 
-      if (IS_RECORD_DATA) {
-        if (GTE_VERSION_3_13) {
-          this._baseRecordData = this.storeWrapper.recordDataFor(dasherize(baseModelName), this.id);
-        } else {
-          this._baseRecordData = this.storeWrapper.recordDataFor(
-            dasherize(baseModelName),
-            this.id,
-            this.clientId
-          );
-        }
+      // TODO: investigate whether this branch is necessary
+      if (GTE_VERSION_3_13) {
+        this._baseRecordData = this.storeWrapper.recordDataFor(dasherize(baseModelName), this.id);
       } else {
-        this._baseRecordData = this.storeWrapper.modelDataFor(
+        this._baseRecordData = this.storeWrapper.recordDataFor(
           dasherize(baseModelName),
           this.id,
           this.clientId

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -12,7 +12,6 @@ import {
   getOrCreateRecordFromRecordData,
   resolveReferencesWithInternalModels,
 } from './utils/resolve';
-import { IS_RECORD_DATA } from 'ember-m3/-infra/versions';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 
 let EmbeddedInternalModel;
@@ -35,10 +34,6 @@ if (!CUSTOM_MODEL_CLASS) {
         this
       );
       this._recordData = recordData;
-
-      if (!IS_RECORD_DATA) {
-        this._modelData = recordData;
-      }
 
       this.parentInternalModel = parentInternalModel;
 

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -1,17 +1,3 @@
-import require from 'require';
-import StoreMixin from '../mixins/store';
-import { HAS_EMBER_DATA_PACKAGE } from 'ember-m3/-infra/packages';
+import Store from '@ember-data/store';
 
-let Store;
-let ExportedStore;
-
-if (!HAS_EMBER_DATA_PACKAGE) {
-  Store = require('@ember-data/store').default;
-  ExportedStore = Store.extend(StoreMixin);
-} else {
-  // the re-open in the initializer will handle configuration
-  // in this case
-  ExportedStore = require('ember-data/store').default;
-}
-
-export default ExportedStore;
+export default Store;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -29,23 +29,7 @@ module.exports = function() {
           },
         },
         {
-          name: 'ember-lts-3.8',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.8.0',
-              'ember-data': '~3.8.0',
-              '@ember-data/store': null,
-              '@ember-data/debug': null,
-              '@ember-data/model': null,
-              '@ember-data/serializer': null,
-              '@ember-data/adapter': null,
-              '@ember-data/record-data': null,
-              'ember-inflector': null,
-            },
-          },
-        },
-        {
-          name: 'ember-lts-3.12',
+          name: 'ember-lts-n-1',
           npm: {
             devDependencies: {
               'ember-source': '~3.12.0',
@@ -61,7 +45,7 @@ module.exports = function() {
           },
         },
         {
-          name: 'ember-lts-3.16',
+          name: 'ember-lts',
           npm: {
             devDependencies: {
               'ember-source': '~3.16.0',
@@ -73,24 +57,6 @@ module.exports = function() {
               '@ember-data/adapter': null,
               '@ember-data/record-data': null,
               'ember-inflector': null,
-            },
-          },
-        },
-        {
-          // EmberData 3.14 is the first version in which we allow
-          // consumers to begin consuming individual packages
-          name: 'ember-data-packages-3.14',
-          npm: {
-            devDependencies: {
-              'ember-source': '~3.14.0',
-              'ember-data': null,
-              '@ember-data/store': '~3.14.0',
-              '@ember-data/debug': null, // available in 3.15
-              '@ember-data/model': '~3.14.0', // not yet droppable (Errors)
-              '@ember-data/serializer': null,
-              '@ember-data/adapter': null,
-              '@ember-data/record-data': null,
-              'ember-inflector': '^3.0.1',
             },
           },
         },
@@ -146,8 +112,8 @@ module.exports = function() {
           name: 'release-n-1',
           npm: {
             devDependencies: {
-              'ember-source': '~3.14.3',
-              'ember-data': '~3.14.0',
+              'ember-source': '~3.17.0',
+              'ember-data': '~3.17.0',
               '@ember-data/store': null,
               '@ember-data/debug': null,
               '@ember-data/model': null,

--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
     "@commitlint/travis-cli": "^8.3.5",
-    "@ember-data/debug": "^3.17.0",
-    "@ember-data/model": "^3.17.0",
-    "@ember-data/store": "^3.17.0",
+    "@ember-data/debug": "^3.18.0",
+    "@ember-data/model": "^3.18.0",
+    "@ember-data/store": "^3.18.0",
     "@ember/optional-features": "^1.3.0",
     "@malleatus/nyx": "^0.2.0",
     "@octokit/rest": "^17.6.0",

--- a/src/debug-macros.js
+++ b/src/debug-macros.js
@@ -65,10 +65,7 @@ function getFlags(app, isDevelopingAddon) {
   let features;
   let packages;
   let versions = {
-    GTE_VERSION_3_12: gte(version, '3.12.0-alpha.0'),
-    GTE_VERSION_3_5_1: dataPackage ? gte(version, '3.5.1') : true,
     GTE_VERSION_3_13: gte(version, '3.13.0'),
-    IS_RECORD_DATA: dataPackage ? gte(version, '3.5.0') : true,
   };
   try {
     features = app.project.require('@ember-data/private-build-infra/src/features')(isProd);
@@ -109,5 +106,4 @@ function debugMacros(app, isDevelopingAddon) {
 
 module.exports = {
   debugMacros,
-  getFlags,
 };

--- a/tests/interop/model-test.js
+++ b/tests/interop/model-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
-import { GTE_VERSION_3_5_1 } from 'ember-m3/-infra/versions';
 
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
@@ -316,49 +315,47 @@ module('unit/m3-model (interop with @ember-data/model)', function(hooks) {
     assert.equal(get(relatedItems, 'length'), 2, 'array has right length');
   });
 
-  if (GTE_VERSION_3_5_1) {
-    test('DS.Models can have relationships into m3 models', function(assert) {
-      let model = run(() => {
-        return this.store.push({
-          data: {
-            id: '3',
-            type: 'author',
-            attributes: {
-              name: 'JK Rowling',
-            },
-            relationships: {
-              publishedBooks: {
-                data: [
-                  {
-                    id: 'isbn:9780439708180',
-                    // Ember-Data requires model-name normalized types in relationship portions of a jsonapi resource
-                    type: 'com.example.bookstore.book',
-                  },
-                ],
-              },
+  test('DS.Models can have relationships into m3 models', function(assert) {
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: '3',
+          type: 'author',
+          attributes: {
+            name: 'JK Rowling',
+          },
+          relationships: {
+            publishedBooks: {
+              data: [
+                {
+                  id: 'isbn:9780439708180',
+                  // Ember-Data requires model-name normalized types in relationship portions of a jsonapi resource
+                  type: 'com.example.bookstore.book',
+                },
+              ],
             },
           },
+        },
 
-          included: [
-            {
-              id: 'isbn:9780439708180',
-              type: 'com.example.bookstore.Book',
-              attributes: {
-                name: `Harry Potter and the Sorcerer's Stone`,
-              },
+        included: [
+          {
+            id: 'isbn:9780439708180',
+            type: 'com.example.bookstore.Book',
+            attributes: {
+              name: `Harry Potter and the Sorcerer's Stone`,
             },
-          ],
-        });
+          },
+        ],
       });
-
-      assert.equal(get(model, 'name'), 'JK Rowling', 'ds.model loaded');
-      assert.equal(
-        get(model, 'publishedBooks.firstObject.name'),
-        `Harry Potter and the Sorcerer's Stone`,
-        'ds.model can access m3 model via relationship'
-      );
     });
-  }
+
+    assert.equal(get(model, 'name'), 'JK Rowling', 'ds.model loaded');
+    assert.equal(
+      get(model, 'publishedBooks.firstObject.name'),
+      `Harry Potter and the Sorcerer's Stone`,
+      'ds.model can access m3 model via relationship'
+    );
+  });
 
   test('store.modelFor', function(assert) {
     let bookModel = this.store.modelFor('com.example.bookstore.Book');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1057,7 +1057,7 @@
     ember-cli-babel "^7.18.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/debug@^3.17.0":
+"@ember-data/debug@^3.18.0":
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/@ember-data/debug/-/debug-3.18.0.tgz#3ce284ce89e83b05ceae81a5be03248a341591fb"
   integrity sha512-9g/ghkq8SLmbOG0UUTyeX0ZAmQ3j3us2Ajkg8u3pVDKEpNdbQLhU5Npd9rf5gJe1TKmLcH7AcDpu85ZPLbb69w==
@@ -1068,7 +1068,7 @@
     ember-cli-test-info "^1.0.0"
     ember-cli-typescript "^3.1.3"
 
-"@ember-data/model@^3.17.0":
+"@ember-data/model@^3.18.0":
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/@ember-data/model/-/model-3.18.0.tgz#f2aebb34005dd2926cf11810d3b3cf7f2cc6c5ff"
   integrity sha512-faFCpBl6VBzPl6tcJKi7FVEnC9xcx3qnle70tJWTAC++MK+GHlpQofNPWVu6cCebfDojHrLszfxjrDzmjvizqQ==
@@ -1121,7 +1121,7 @@
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
   integrity sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==
 
-"@ember-data/store@3.18.0", "@ember-data/store@^3.17.0":
+"@ember-data/store@3.18.0", "@ember-data/store@^3.18.0":
   version "3.18.0"
   resolved "https://registry.yarnpkg.com/@ember-data/store/-/store-3.18.0.tgz#04f7734a1f654c4eaf999f94f5a1451e763b7670"
   integrity sha512-FBfXqRct3khpUsdusdFVFt8qNrWDPpqT/V0wFnwjSje5uX+DSwZ247SrtCYkwf6OziSzOfWR/w286O+0nawAyQ==


### PR DESCRIPTION
This will be a major version bump (2.0.0)
This aims to drop unused branching, improving hygiene and reducing complexity.

- [x] un-wip