### PR TITLE
fix: update should trigger flush without included

### DIFF
--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -268,4 +268,15 @@ export default class M3Store extends Store {
       return internalModel;
     }
   }
+
+  // this private hook is used for update/create/delete record responses which don't
+  // take the _push codepath
+  didSaveRecord() {
+    super.didSaveRecord(...arguments);
+    // EmberData wraps the call to didSaveRecord in a run.join of
+    // it's internal backburner, and pushes sideloaded data from
+    // included after calling this hook. So in order to batch alongside
+    // anything in `included` we need to schedule
+    this._backburner.schedule('finished', () => flushChanges(this));
+  }
 }

--- a/tests/interop/store-test.js
+++ b/tests/interop/store-test.js
@@ -158,7 +158,7 @@ module('unit/store (interop with @ember-data/model)', function(hooks) {
     await book.save();
   });
 
-  skip('didSave with no included resources flushes changed notifications', async function(assert) {
+  test('didSave with no included resources flushes changed notifications', async function(assert) {
     assert.expect(2);
 
     this.owner.register(

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -38,6 +38,7 @@ module('unit/record-data', function(hooks) {
     let schemaManager = (this.schemaManager = this.owner.lookup('service:m3-schema-manager'));
 
     let storeWrapper = (this.storeWrapper = {
+      _store: {},
       recordDatas: {},
       disconnectedRecordDatas: {},
 

--- a/tests/unit/store-test.js
+++ b/tests/unit/store-test.js
@@ -139,8 +139,8 @@ module('unit/store', function(hooks) {
     await book.save();
   });
 
-  skip('didSave with no included resources flushes changed notifications', async function(assert) {
-    assert.expect(2);
+  test('didSave with no included resources flushes changed notifications', async function(assert) {
+    assert.expect(5);
 
     this.owner.register(
       'adapter:application',
@@ -179,11 +179,14 @@ module('unit/store', function(hooks) {
     addObserver(book, 'volume', () => {
       assert.ok(true, 'changes flushed');
     });
-    book.get('volume');
+    assert.equal(book.get('volume'), 1, 'volume initialized');
 
     book.set('author', 'Winston Churchill');
     assert.equal(book.get('isDirty'), true, 'book now dirty');
 
     await book.save();
+
+    assert.equal(book.get('isDirty'), false, 'book now clean');
+    assert.equal(book.get('volume'), 2, 'volume updated');
   });
 });


### PR DESCRIPTION
This uses an intimate API (`store.didSaveRecord`) to capture the return of updates and schedule a flush of the changes.

The schedule is only because of our desire to batch these notifications with any generated from `included` records, if we don't care about the batching we can just call flushChanges straight up and it would affect only the primary data while a separate flush would occur for the changes from `included`.

I explored two other alternatives that achieve this, both have downsides.

1) flush within `RecordData.didCommit`. This only works if we use `run.next` or similar to defer the flush until after the changes are notified (notifications are generated based on the returned changedKeys generated by `didCommit`). It requires accessing the `StoreWrapper._store` to get the weak map key as well.

2) chaining the promise within the resolver given to the private `store.scheduleSave` method to perform the flush. This felt more brittle.

Regardless of approach taken here (including closing without merging) we should work to ensure this is possible via public API in EmberData.