### PR TITLE
easier transformValue overriding

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -415,7 +415,8 @@ export default class MegamorphicModel extends EmberObject {
       }
     }
 
-    let value = this._schema.transformValue(this._modelName, key, rawValue);
+    let value = this._transformValue(this._modelName, key, rawValue);
+
     return (this._cache[key] = resolveValue(
       key,
       value,
@@ -424,6 +425,10 @@ export default class MegamorphicModel extends EmberObject {
       this._schema,
       this
     ));
+  }
+
+  _transformValue(modelName, key, rawValue) {
+    return this._schema.transformValue(modelName, key, rawValue);
   }
 
   get id() {

--- a/addon/model.js
+++ b/addon/model.js
@@ -432,7 +432,7 @@ export default class MegamorphicModel extends EmberObject {
   }
 
   _transformValue(modelName, key, rawValue) {
-    return this._schema.transformValue(modelName, key, rawValue, this._topModel);
+    return this._schema.transformValue(modelName, key, rawValue);
   }
 
   get id() {

--- a/addon/model.js
+++ b/addon/model.js
@@ -407,7 +407,7 @@ export default class MegamorphicModel extends EmberObject {
         return get(this, key);
       }
 
-      let defaultValue = this._schema.getDefaultValue(this._modelName, key);
+      let defaultValue = this._getDefaultValue(this._modelName, key);
 
       // If default value is not defined, resolve the key for reference
       if (defaultValue !== undefined) {
@@ -427,8 +427,12 @@ export default class MegamorphicModel extends EmberObject {
     ));
   }
 
+  _getDefaultValue(modelName, key) {
+    return this._schema.getDefaultValue(modelName, key);
+  }
+
   _transformValue(modelName, key, rawValue) {
-    return this._schema.transformValue(modelName, key, rawValue);
+    return this._schema.transformValue(modelName, key, rawValue, this._topModel);
   }
 
   get id() {


### PR DESCRIPTION
Easier to extend the transform functionality without much hassle, In my particular use case I had to send more params to `this._schema.transformValue`, like `_topModel`

The reality is that I have structured schema with the type information for each attr, a [json schema](https://json-schema.org/) so each Megamorphic topModel have a json schema, so all the transforms and default values must be read from this schema per access, so my method call reads like this `this._schema.transformValue(this._modelName, key, value, this._topModel.schemaVersion)` and probably I would also favor `this._schema.getDefaultValue(this._modelName, key, this._topModel.schemaVersion)` 

```ts
_getDefaultValue(modelName, key){
  return this._schema.getDefaultValue(modelName, key)
}
_transformValue(modelName, key, value){
  return this._schema.transformValue(modelName, key, value)
}
```
So now I can easily do
```ts

MegamorphicModel.reopen({
  schemaVersion: computed('_topModel', function() {
    return this.get('_topModel.schema_version_id');
  }),

  _getDefaultValue(modelName, key) {
    return this._schema.getDefaultValue(modelName, key, this.schemaVersion);
  },

  _transformValue(modelName, key, rawValue) {
    return this._schema.transformValue(modelName, key, rawValue, this.schemaVersion);
  }
});

```