### PR TITLE
temporary stringify fix

### DIFF
--- a/addon/adapters/m3-debug-adapter.js
+++ b/addon/adapters/m3-debug-adapter.js
@@ -25,7 +25,7 @@ export default class M3DebugAdapter extends DataAdapter {
   }
 
   /**
-    Iterates through objects and if there is a nested object or array, stringifies the value
+    Clones the nestedJSON to avoid mutating references then iterates through objects and if there is a nested object or array, stringifies the value
     This is needed because Ember Inspector does not support data structures more than two levels deep
     @private
     @method _stringifyNestedValues

--- a/addon/adapters/m3-debug-adapter.js
+++ b/addon/adapters/m3-debug-adapter.js
@@ -33,6 +33,7 @@ export default class M3DebugAdapter extends DataAdapter {
     @return Object with stringified values as needed
   */
   _stringifyNestedValues(nestedJSON) {
+    nestedJSON = JSON.parse(JSON.stringify(nestedJSON));
     for (let key in nestedJSON) {
       const nestedJSONValue = nestedJSON[key];
       if (nestedJSONValue instanceof Object) {


### PR DESCRIPTION
Temporary fix for #807 

The bug happens when iterating over _recordValues and find a reference to another [_MegamorphicModel_](https://github.com/hjdivad/ember-m3/blob/971f3764b1aa7121e34ade4df82eaea8026d8b75/addon/adapters/m3-debug-adapter.js#L55)... 

`record.debugJSON()` returns the `recordData`'s, `_data`, the last known data from the server inside `recordData._data`... so it returns the [reference](https://github.com/hjdivad/ember-m3/blob/971f3764b1aa7121e34ade4df82eaea8026d8b75/addon/record-data.js#L923) and [this method](https://github.com/hjdivad/ember-m3/blob/971f3764b1aa7121e34ade4df82eaea8026d8b75/addon/adapters/m3-debug-adapter.js#L35) is modifying the reference, which leads to this bug... this is _always_ happens, and leads to other kind of more "serious" bugs like changedAttributes stuff, maybe this also helps #769 ?

![Screen Shot 2020-08-02 at 14 48 23](https://user-images.githubusercontent.com/9092644/89130975-39b98600-d4cf-11ea-9e66-c947a01c21c4.png)

also since m3 lazily access/calculates stuff via unknownProperty , in the scenario of a corrupted/stringified `recordData._data`, accessing the props returns the stringified value. 

![Screen Shot 2020-08-02 at 15 14 39](https://user-images.githubusercontent.com/9092644/89131501-e3e6dd00-d4d2-11ea-8e70-2a0c93dc8c62.png)


The easy solution _for now_ is just cloning, what do you think @SYU15 @igorT ?

