### PR TITLE
ci: Drop Node 13 and add Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [10.x, 12.x, 13.x] # LTS + current
+        node: [10.x, 12.x, 14.x] # LTS + current
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Node 13 was EOL at the end of May this year. This doesn’t really change anything regarding our supported Node’s, but it ensures that CI is running on the platforms we support.

https://nodejs.org/en/about/releases/