### PR TITLE
Avoid `checker.check` when project depends on ember-data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 'use strict';
+const semver = require('semver');
 const Funnel = require('broccoli-funnel');
 const getDebugMacros = require('./src/debug-macros').debugMacros;
 
@@ -28,9 +29,15 @@ module.exports = {
   included() {
     this._super.included.call(this, ...arguments);
 
-    assertValidEmberData(this);
-
     this.configureBabelOptions();
+
+    let emberDataMetaPackage = this.project.addons.find((a) => a.name === 'ember-data');
+
+    if (emberDataMetaPackage === undefined) {
+      assertValidEmberData(this);
+    } else if (semver.lt(emberDataMetaPackage.pkg.version, '3.16.0')) {
+      throw new Error('[ember-m3] requires ember-data@3.16.0 or higher.');
+    }
   },
 
   treeForAddon(tree) {


### PR DESCRIPTION
When the project depends on a recent enough version of `ember-data` meta package we do not need to check for the individual packages themselves (they are handled by the meta package).

When `ember-cli-version-checker`'s `check()` API is used in an application with a massive number of addons (> 100,000), it takes a massive amount of time to run. This avoids that specific issue (while we work through the algorithmic issues there) by avoiding the check in the simple case where the project has a direct dependency on `ember-data`.