### PR TITLE
Avoid checking project dependencies more than once per project

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,19 @@
 /* eslint-env node */
 'use strict';
-const semver = require('semver');
+
 const Funnel = require('broccoli-funnel');
 const getDebugMacros = require('./src/debug-macros').debugMacros;
 
 const VersionChecker = require('ember-cli-version-checker');
 
-function assertValidEmberData(addon) {
-  let checker = VersionChecker.forProject(addon.project);
+const CHECKED_PROJECT = new WeakSet();
+
+function assertValidEmberData(project) {
+  if (CHECKED_PROJECT.has(project)) {
+    return;
+  }
+
+  let checker = VersionChecker.forProject(project);
 
   // full ember-data brings store and model starting in 3.16
   // so we do not need to check for full ember-data, just the specific packages
@@ -21,6 +27,8 @@ function assertValidEmberData(addon) {
   check.assert(
     '[ember-m3] requires either "ember-data" be installed (which brings the below packages) or at least the following versions of them.'
   );
+
+  CHECKED_PROJECT.add(project);
 }
 
 module.exports = {
@@ -29,15 +37,9 @@ module.exports = {
   included() {
     this._super.included.call(this, ...arguments);
 
+    assertValidEmberData(this.project);
+
     this.configureBabelOptions();
-
-    let emberDataMetaPackage = this.project.addons.find((a) => a.name === 'ember-data');
-
-    if (emberDataMetaPackage === undefined) {
-      assertValidEmberData(this);
-    } else if (semver.lt(emberDataMetaPackage.pkg.version, '3.16.0')) {
-      throw new Error('[ember-m3] requires ember-data@3.16.0 or higher.');
-    }
   },
 
   treeForAddon(tree) {


### PR DESCRIPTION
backport #836 

The original code was written to validate that the project has the required dependencies inside the `included` hook. This works perfectly fine and is _not_ overly slow (takes ~500ms in a **massive** application). This `included` hook is called once for every `ember-m3` addon instance in the addon graph.

Unfortunately, in some applications you may have a shared `data-layer` package that depends on `ember-m3`, and that `data-layer` package is depended on hundreds of other dependencies. In that scenario, the 500ms cost is multiplied by each `ember-m3` instance which results in a much larger overall cost (~ 200s).

The good news is that this is **very easy** for us to resolve! We are already checking the global project instance (which is the same across all of the `ember-m3` instances), so we just need to ensure we only do the validation once for each unique project.

That is exactly what this change does: it adds a simple `WeakSet` cache to ensure we only do this check one time per-project.