### PR TITLE
Replace `new Object(null)` with `Object.create(null)`.

### DIFF
--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -18,8 +18,8 @@ export default class QueryCache {
   constructor({ store }) {
     this._store = store;
     this._recordArrayManager = this._store.recordArrayManager;
-    this._queryCache = new Object(null);
-    this._reverseQueryCache = new Object(null);
+    this._queryCache = Object.create(null);
+    this._reverseQueryCache = Object.create(null);
     this.__adapter = null;
     this.__serializer = null;
   }

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -82,12 +82,12 @@ export default class M3Store extends Store {
 
     this._modifiedInternalModelMapProto = undefined;
     if (CUSTOM_MODEL_CLASS) {
-      this._globalM3RecordDataCache = new Object(null);
+      this._globalM3RecordDataCache = Object.create(null);
       this._recordDataToRecordMap = recordDataToRecordMap;
       let defaultSchema = this.getSchemaDefinitionService();
       this.registerSchemaDefinitionService(new SchemaDefinition(this, defaultSchema));
     } else {
-      this._globalM3Cache = new Object(null);
+      this._globalM3Cache = Object.create(null);
     }
   }
 

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -63,7 +63,7 @@ for (let testRun = 0; testRun < 2; testRun++) {
     hooks.beforeEach(function () {
       this.sinon = sinon.createSandbox();
 
-      let globalCache = new Object(null);
+      let globalCache = Object.create(null);
       if (testRun === 0) {
         this.owner.register('service:m3-schema', TestSchemaOldHooks);
       } else if (testRun === 1) {


### PR DESCRIPTION
AFAICT `new Object(null)` is no different than `new Object` which is no different from `{}`, but in these cases we _actually_ want an empty dictionary (without prototype pollution).