### PR TITLE
queryURL can resolve primitive values

### DIFF
--- a/addon/query-cache.js
+++ b/addon/query-cache.js
@@ -59,9 +59,15 @@ export default class QueryCache {
             cacheKey,
             'queryURL'
           );
-          if (payload === null || payload === undefined) {
+          if (
+            payload === null ||
+            payload === undefined ||
+            typeof payload !== 'object' ||
+            Array.isArray(payload)
+          ) {
             return payload;
           }
+
           let result = this._createResult(payload, { url, params, method, cacheKey }, array);
           // Add result to reverseCache.
           if (cacheKey) {

--- a/tests/unit/query-cache-test.js
+++ b/tests/unit/query-cache-test.js
@@ -393,6 +393,40 @@ module('unit/query-cache', function (hooks) {
     });
   });
 
+  test('.queryURL can resolve with primitives', async function (assert) {
+    this.adapterAjax.returns(resolve(123));
+    let result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.strictEqual(result, 123, 'queryURL → number');
+
+    this.adapterAjax.returns(resolve(false));
+    result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.strictEqual(result, false, 'queryURL → boolean');
+
+    this.adapterAjax.returns(resolve('amazing'));
+    result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.strictEqual(result, 'amazing', 'queryURL → string');
+
+    this.adapterAjax.returns(resolve(null));
+    result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.strictEqual(result, null, 'queryURL → null');
+
+    this.adapterAjax.returns(resolve([123]));
+    result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.deepEqual(result, [123], 'queryURL → [number]');
+
+    this.adapterAjax.returns(resolve([false]));
+    result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.deepEqual(result, [false], 'queryURL → [boolean]');
+
+    this.adapterAjax.returns(resolve(['amazing']));
+    result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.deepEqual(result, ['amazing'], 'queryURL → [string]');
+
+    this.adapterAjax.returns(resolve([null]));
+    result = await this.queryCache.queryURL('/uwot', { reload: true });
+    assert.deepEqual(result, [null], 'queryURL → [null]');
+  });
+
   test('.queryURL can resolve with a record array of models', function (assert) {
     let payload = {
       data: [


### PR DESCRIPTION
Previously queryURL would only be able to resolve

  1) Ember Data compatible JSON:API documents and
  2) null or undefined

[fix #750]
