### PR TITLE
Fix keeping embedded records in sync inside projections

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -1016,6 +1016,10 @@ export default class M3RecordData {
    * @param {string} addLength
    */
   _resizeChildRecordData(key, idx, removeLength, addLength) {
+    if (this._baseRecordData) {
+      this._baseRecordData._resizeChildRecordData(key, idx, removeLength, addLength);
+    }
+
     const childRecordDatas = this._childRecordDatas && this._childRecordDatas[key];
     if (!childRecordDatas) {
       return;

--- a/tests/unit/projection-test.js
+++ b/tests/unit/projection-test.js
@@ -45,10 +45,13 @@ function computeAttributeReference(key, value, modelName, schemaInterface, model
       id: parts[2],
     };
   } else if (Array.isArray(value)) {
+    if (key === 'similarAuthors') {
+      return;
+    }
     return value
       .map((v) => {
         let type = null;
-        let modelSchema = this.models[modelName];
+        let modelSchema = models[modelName];
 
         if (modelSchema && modelSchema.attributesTypes && modelSchema.attributesTypes[key]) {
           type = modelSchema.attributesTypes[key];
@@ -63,6 +66,9 @@ function computeAttributeReference(key, value, modelName, schemaInterface, model
   }
 }
 function computeNestedModel(key, value, modelName, schemaInterface, models) {
+  if (Array.isArray(value)) {
+    return;
+  }
   if (!value || typeof value !== 'object' || value.constructor === Date) {
     return null;
   }
@@ -93,7 +99,15 @@ const Models = {
     },
     // if you want to project an embedded model then it must have a type
     //  computedEmbeddedType
-    attributes: ['title', 'author', 'chapter-1', 'year', 'publisher', 'otherBooksInSeries'],
+    attributes: [
+      'title',
+      'author',
+      'chapter-1',
+      'year',
+      'publisher',
+      'otherBooksInSeries',
+      'similarAuthors',
+    ],
   },
   [NORM_PUBLISHER_CLASS]: {},
   // this schema must come with the parent schema
@@ -572,6 +586,54 @@ for (let testRun = 0; testRun < 2; testRun++) {
           NEW_AUTHOR_NAME,
           'excerpt has the correct author.name'
         );
+      });
+
+      test('Updating an embedded object property to null can still be updated again', function (assert) {
+        const BOOK_ID = 'isbn:9780439708181';
+        const AUTHOR_NAME = 'Lewis Carroll';
+        const NEW_AUTHOR_NAME = 'J.K. Rowling';
+
+        let { store } = this;
+
+        let projectedBook;
+
+        run(() => {
+          store.push({
+            data: {
+              id: BOOK_ID,
+              type: BOOK_CLASS_PATH,
+              attributes: {
+                author: {
+                  name: AUTHOR_NAME,
+                },
+                similarAuthors: [{ type: 'someType', name: NEW_AUTHOR_NAME }],
+              },
+            },
+          });
+
+          projectedBook = store.push({
+            data: {
+              id: BOOK_ID,
+              type: BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+              attributes: {},
+            },
+          });
+        });
+
+        let similarAuthors = projectedBook.get('similarAuthors');
+        assert.equal(
+          similarAuthors.objectAt(0).get('name'),
+          NEW_AUTHOR_NAME,
+          'Starts off with correct author name'
+        );
+        similarAuthors.removeAt(0);
+        similarAuthors.pushObject({
+          type: 'someType',
+          location: 'San Francisco',
+        });
+        let newAuthor = projectedBook.get('similarAuthors').objectAt(0);
+        assert.equal(newAuthor.get('location'), 'San Francisco', 'Has the correct new property');
+        assert.equal(newAuthor.get('name'), null, 'Does not have the old data');
       });
 
       module('property notifications on top-level attributes', function (hooks) {


### PR DESCRIPTION
If you removed a record from an array of nested records, we did not update the baseRecordData, which thus kept the original nested childRecordData. If you then pushed a new object in, it would merge the new object with the previously removed data, leading to incorrect results.

It seems very likely that there are other issues with childRecordData projection syncing, that we should investigate.