### PR TITLE
only execute callback once per key for eachAttribute

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -616,19 +616,22 @@ export default class M3RecordData {
       return this._baseRecordData.eachAttribute(callback, binding);
     }
 
+    let attrs = {};
     if (this.__attributes !== null) {
-      Object.keys(this._attributes).forEach(callback, binding);
+      Object.keys(this._attributes).forEach((key) => (attrs[key] = true));
     }
 
     if (this.__inFlightAttributes !== null) {
-      Object.keys(this._inFlightAttributes).forEach(callback, binding);
+      Object.keys(this._inFlightAttributes).forEach((key) => (attrs[key] = true));
     }
 
     if (this.__data !== null) {
       this._schema
         .computeAttributes(Object.keys(this._data), this.modelName)
-        .forEach(callback, binding);
+        .forEach((key) => (attrs[key] = true));
     }
+
+    Object.keys(attrs).forEach(callback, binding);
   }
 
   // Exposes attribute keys for the schema service to be able to iterate over the props

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -154,6 +154,44 @@ for (let testRun = 0; testRun < 2; testRun++) {
       assert.deepEqual(attrsIterated, ['localAttr', 'inFlightAttr', 'dataAttr']);
     });
 
+    test(`.eachAttribute callback fires only once per attribute name`, function (assert) {
+      let recordData = new M3RecordData(
+        'com.exmaple.bookstore.book',
+        '1',
+        null,
+        this.storeWrapper,
+        this.schemaManager,
+        null,
+        null,
+        {}
+      );
+
+      recordData.pushData(
+        {
+          id: '1',
+          attributes: {
+            dataAttr: 'value',
+          },
+        },
+        false
+      );
+
+      recordData.setAttr('dataAttr', 'changed dataAttr');
+      recordData.setAttr('inFlightAttr', 'value');
+      recordData.willCommit();
+      recordData.setAttr('localAttr', 'value');
+
+      let attributeCallbackCounters = {
+        localAttr: 0,
+        inFlightAttr: 0,
+        dataAttr: 0,
+      };
+
+      recordData.eachAttribute((attr) => attributeCallbackCounters[attr]++);
+
+      assert.deepEqual(attributeCallbackCounters, { localAttr: 1, dataAttr: 1, inFlightAttr: 1 });
+    });
+
     test(`.getServerAttr returns the server state`, function (assert) {
       let recordData = new M3RecordData(
         'com.exmaple.bookstore.book',


### PR DESCRIPTION
Hello, I just noticed something I consider a bug, but not sure if it's actually a bug, or intended.

When `MegamorphicModel.eachAttribute` is called, the callback is executed more than once per `key` if its on multiple "buckets" i.e. `this._attributes` and `this._data`

![Screen Shot 2021-03-06 at 11 38 39](https://user-images.githubusercontent.com/9092644/110215750-0aa63100-7e71-11eb-8458-9e2ea1c9b66b.png)