### PR TITLE
fix: outer object replacement and nested property change bugfix

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -692,7 +692,8 @@ export default class M3RecordData {
           if (Object.keys(childChangedAttributes).length > 0) {
             if (
               this.getServerAttr(childKey) !== null &&
-              this.getServerAttr(childKey) !== undefined
+              this.getServerAttr(childKey) !== undefined &&
+              newData[childKey] === undefined // If object is not already staged for change
             ) {
               _changedAttributes[childKey] = childChangedAttributes;
             } else {

--- a/tests/unit/model/changed-attrs-test.js
+++ b/tests/unit/model/changed-attrs-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+import QUnit, { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
 import EmberObject, { get, set } from '@ember/object';
@@ -327,6 +327,114 @@ for (let testRun = 0; testRun < 2; testRun++) {
           model.changedAttributes(),
           { author: [null, { name: [undefined, 'Chris'] }] },
           'Changed attributes for the parent model is correct'
+        );
+      });
+
+      test('.changedAttributes returns [ object, object ] for object replacement and leaf property change', function (assert) {
+        QUnit.dump.maxDepth = 10;
+        assert.expect(1);
+
+        let model = run(() => {
+          return this.store.push({
+            data: {
+              id: 1,
+              type: 'com.example.bookstore.Book',
+              attributes: {
+                reports: {
+                  highlyRated: {
+                    reportOne: {
+                      author: 'JK Rowling',
+                      reportDate: '2020-01-01',
+                    },
+                  },
+                },
+              },
+            },
+          });
+        });
+
+        model.set('reports', { highlyRated: { reportOne: {} } });
+        let reportOne = model.get('reports.highlyRated.reportOne');
+        reportOne.set('author', 'William Shakespeare');
+
+        assert.deepEqual(
+          model.changedAttributes(),
+          {
+            reports: [
+              {
+                highlyRated: {
+                  reportOne: {
+                    author: 'JK Rowling',
+                    reportDate: '2020-01-01',
+                  },
+                },
+              },
+              {
+                highlyRated: {
+                  reportOne: {
+                    author: [undefined, 'William Shakespeare'],
+                  },
+                },
+              },
+            ],
+          },
+          'Changed attributes for the model is correct'
+        );
+      });
+
+      test('.changedAttributes returns [ object, object ] for object replacement with deeply nested object', function (assert) {
+        QUnit.dump.maxDepth = 10;
+        assert.expect(1);
+
+        let model = run(() => {
+          return this.store.push({
+            data: {
+              id: 1,
+              type: 'com.example.bookstore.Book',
+              attributes: {
+                reports: {
+                  highlyRated: {
+                    reportOne: {
+                      author: 'JK Rowling',
+                      reportDate: '2020-01-01',
+                    },
+                  },
+                },
+              },
+            },
+          });
+        });
+
+        model.set('reports', {
+          highlyRated: {
+            reportOne: {
+              author: 'William Shakespeare',
+            },
+          },
+        });
+
+        assert.deepEqual(
+          model.changedAttributes(),
+          {
+            reports: [
+              {
+                highlyRated: {
+                  reportOne: {
+                    author: 'JK Rowling',
+                    reportDate: '2020-01-01',
+                  },
+                },
+              },
+              {
+                highlyRated: {
+                  reportOne: {
+                    author: 'William Shakespeare',
+                  },
+                },
+              },
+            ],
+          },
+          'Changed attributes for the model is correct'
         );
       });
 


### PR DESCRIPTION
## Bug
Top level object change is squashed by nested property change. We want the top level object change to remain intact.

## Recreate
The bug occurs when there's a nested object change such as:
```
let model = run(() => {
  return this.store.push({
    data: {
      id: 1,
      type: 'com.example.bookstore.Book',
      attributes: {
        reports: {
          highlyRated: {
            reportOne: {
              author: 'JK Rowling',
              reportDate: '2020-01-01',
            },
          },
        },
      },
    },
  });
});

model.set('reports', {
    highlyRated: {
      reportOne: {},
    },
  });
```

And another nested property is changed such as:
```
model.get('reports.highlyRated.reportOne');
reportOne.set('author', 'William Shakespeare');
```

## Root cause
Line 697 of `addon/record-data#changedAttributes` replaces the original change indicator for `reports` set in `_changedAttributes` on line 667