### PR TITLE
Adds support for native Proxy behind a canary feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,20 @@ jobs:
       - name: test:feature-flags
         run: yarn run ember try:one canary-channel --- ember test --query enableoptionalfeatures
 
+  test-proxy:
+    name: proxy
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '10.x' # min node version
+      - name: yarn install
+        run: yarn --frozen-lockfile --install
+      - name: test:feature-flags
+        run: yarn run ember try:one canary-channel --- ember test --query enableproxy
+
   test-node:
     name: 't:' # rely on matrix for most of name
     needs: [lint, test, test-feature-flags]

--- a/addon/-infra/features.js
+++ b/addon/-infra/features.js
@@ -12,7 +12,7 @@ import require, { has } from 'require';
   The file itself is stripped from production builds.
 */
 
-function flagState(flagName) {
+function dataFlagState(flagName) {
   let value;
   if (has('@ember-data/canary-features')) {
     value = require('@ember-data/canary-features')[flagName];
@@ -20,4 +20,9 @@ function flagState(flagName) {
   return value || false;
 }
 
-export const CUSTOM_MODEL_CLASS = flagState('CUSTOM_MODEL_CLASS');
+function m3FlagState(flagName) {
+  return window.M3ENV?.FEATURES?.[flagName];
+}
+
+export const CUSTOM_MODEL_CLASS = dataFlagState('CUSTOM_MODEL_CLASS');
+export const PROXY_MODEL_CLASS = m3FlagState('PROXY_MODEL_CLASS');

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ module.exports = {
     this.options = this.options || {};
     this.options.babel = this.options.babel || {};
     let plugins = this.options.babel.plugins;
-    let newPlugins = getDebugMacros(app, this.isDevelopingAddon());
+    let newPlugins = getDebugMacros(app);
     this.options.babel.plugins = Array.isArray(plugins) ? plugins.concat(newPlugins) : newPlugins;
 
     this.options.babel.loose = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ember-m3",
   "version": "3.0.0",
+  "isCanary": true,
   "description": "Alternative to @ember-data/model in which attributes and relationships are derived from API Payloads",
   "keywords": [
     "ember-addon",
@@ -48,7 +49,9 @@
     "lint:js": "eslint .",
     "start": "ember server --port=0",
     "test": "yarn test:ember",
-    "test:ember": "ember test"
+    "test:ember": "ember test",
+    "prepublishOnly": "node ./src/prepublish.js",
+    "postpublish": "node ./src/postpublish.js"
   },
   "husky": {
     "hooks": {

--- a/src/debug-macros.js
+++ b/src/debug-macros.js
@@ -1,6 +1,10 @@
 /* eslint-env node */
 'use strict';
 
+const { version, isCanary: _isCanary } = require('../package.json');
+
+const isCanary = _isCanary || version.includes('alpha');
+
 function buildDebugMacros(flags) {
   let plugins = [
     [
@@ -32,35 +36,87 @@ function buildDebugMacros(flags) {
   return plugins;
 }
 
+const M3_FEATURES = {
+  PROXY_MODEL_CLASS: null,
+};
+
+function getM3Features(isProd) {
+  let features = Object.assign({}, M3_FEATURES);
+
+  if (!isCanary) {
+    // disable all features with a current value of `null`
+    for (let feature in features) {
+      let featureValue = features[feature];
+
+      if (featureValue === null) {
+        features[feature] = false;
+      }
+    }
+    return features;
+  }
+
+  const FEATURE_OVERRIDES = process.env.EMBER_M3_FEATURE_OVERRIDE;
+  if (FEATURE_OVERRIDES === 'ENABLE_ALL_OPTIONAL') {
+    // enable all features with a current value of `null`
+    for (let feature in features) {
+      let featureValue = features[feature];
+
+      if (featureValue === null) {
+        features[feature] = true;
+      }
+    }
+  } else if (FEATURE_OVERRIDES === 'DISABLE_ALL') {
+    // disable all features, including those with a value of `true`
+    for (let feature in features) {
+      features[feature] = false;
+    }
+  } else if (FEATURE_OVERRIDES) {
+    // enable only the specific features listed in the environment
+    // variable (comma separated)
+    const forcedFeatures = FEATURE_OVERRIDES.split(',');
+    for (let i = 0; i < forcedFeatures.length; i++) {
+      let featureName = forcedFeatures[i];
+
+      features[featureName] = true;
+    }
+  }
+
+  if (isProd) {
+    // disable all features with a current value of `null`
+    for (let feature in features) {
+      let featureValue = features[feature];
+
+      if (featureValue === null) {
+        features[feature] = false;
+      }
+    }
+  }
+
+  return features;
+}
+
 let _flags;
-function getFlags(app, isDevelopingAddon) {
+function getFlags(app) {
   if (_flags) {
     return _flags;
   }
   let isProd = process.env.EMBER_ENV === 'production';
 
-  let features;
-  let packages;
-
   // >= 3.15.0.beta
-  features = app.project.require('@ember-data/private-build-infra/src/features')(isProd);
+  let dataFeatures = app.project.require('@ember-data/private-build-infra/src/features')(isProd);
+  let m3Features = getM3Features(isProd);
 
-  features = Object.assign({ CUSTOM_MODEL_CLASS: false }, features);
-
-  let allowRuntimeEnable = !isProd && isDevelopingAddon;
-  Object.keys(features).forEach((flag) => {
-    features[flag] = features[flag] || (allowRuntimeEnable ? null : false);
-  });
+  let features = Object.assign(m3Features, dataFeatures);
 
   // >= 3.16
-  packages = app.project.require('@ember-data/private-build-infra/src/packages')(app);
+  let packages = app.project.require('@ember-data/private-build-infra/src/packages')(app);
 
   _flags = { features, packages };
   return _flags;
 }
 
-function debugMacros(app, isDevelopingAddon) {
-  return buildDebugMacros(getFlags(app, isDevelopingAddon));
+function debugMacros(app) {
+  return buildDebugMacros(getFlags(app));
 }
 
 module.exports = {

--- a/src/postpublish.js
+++ b/src/postpublish.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const packagePath = path.resolve(__dirname, '../package.json');
+
+const package = require(packagePath);
+
+package.isCanary = true;
+
+fs.writeFileSync(packagePath, JSON.stringify(package, null, 2) + '\n');

--- a/src/prepublish.js
+++ b/src/prepublish.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const packagePath = path.resolve(__dirname, '../package.json');
+
+const package = require(packagePath);
+
+package.isCanary = false;
+
+fs.writeFileSync(packagePath, JSON.stringify(package, null, 2) + '\n');

--- a/tests/index.html
+++ b/tests/index.html
@@ -29,6 +29,11 @@
       if (QUnit.urlParams.enableoptionalfeatures) {
         window.EmberDataENV = { ENABLE_OPTIONAL_FEATURES: true };
       }
+
+      if (QUnit.urlParams.enableproxy) {
+        window.EmberDataENV = { ENABLE_OPTIONAL_FEATURES: true };
+        window.M3ENV = { FEATURES: { PROXY_MODEL_CLASS: true } };
+      }
     </script>
 
     <script src="{{ rootURL }}assets/dummy.js"></script>

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -11,6 +11,11 @@ QUnit.config.urlConfig.push({
   label: 'Enable Opt Features',
 });
 
+QUnit.config.urlConfig.push({
+  id: 'enableproxy',
+  label: 'Enable Proxy',
+});
+
 setApplication(Application.create(config.APP));
 start({
   setupTestIsolationValidation: true,


### PR DESCRIPTION
Adds support for wrapping M3 models and arrays in a native Proxy,
allowing them to be accessed using Plain JS (tm) syntax. This is still
a work in progress as some functionality, such as `Array.isArray`, does
not work on the arrays, and additionally it is double wrapping
everything with Ember's own proxy system so it is very expensive
overall to enable perf-wise. As such, it is kept behind a feature flag
that can only be enabled in canary builds.