### PR TITLE
Deprecate eager transformValue in favor of computeAttribute 

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -473,10 +473,9 @@ export default class MegamorphicModel extends EmberObject {
       }
     }
 
-    let value = this._schema.transformValue(this._modelName, key, rawValue);
     return (this._cache[key] = resolveValue(
       key,
-      value,
+      rawValue,
       this._modelName,
       this._store,
       this._schema,

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -43,6 +43,14 @@ class M3SchemaInterface {
   }
 
   /**
+   * Returns the topRecordData
+   * @returns {M3RecordData}
+   */
+  topModel() {
+    return this.recordData._topRecordData;
+  }
+
+  /**
    * Mark the passed in object as a nested m3 model
    * @param {Object} object
    */
@@ -773,6 +781,14 @@ export default class M3RecordData {
     }
 
     return originalValue !== this._attributes[key];
+  }
+
+  /**
+   * @readonly
+   * @returns {M3RecordData}
+   */
+  get _topRecordData() {
+    return this._parentRecordData ? this._parentRecordData._topModel : this;
   }
 
   /**

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -135,6 +135,7 @@ export function resolveValue(key, value, modelName, store, schema, record, paren
   } else {
     // TODO remove this if branch once we remove support for old compute hooks
     // We invoke the old hooks and mark the results with the new apis
+    value = schema.transformValue(modelName, key, value);
 
     let computedReference = computeAttributeReference(
       key,

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -27,6 +27,13 @@ Name: {{model._internalModel.modelName}}<br>
               {{#with comment.commenter as |commenter|}}
                 {{commenter._internalModel.modelName}}: {{commenter.id}}<br>
                 {{commenter.name}}
+                {{#with commenter.reputation as |reputation|}}
+                  <br />
+                  {{reputation._internalModel.modelName}}
+                  {{#if reputation.booksReviewed}}
+                    {{reputation.booksReviewed}} books reviewed!
+                  {{/if}}
+                {{/with}}
                 {{#if commenter.favouriteBook}}
                   (<em>Favourite: ({{commenter.favouriteBook.name}})</em>)
                 {{/if}}

--- a/tests/dummy/public/api0.json
+++ b/tests/dummy/public/api0.json
@@ -66,7 +66,11 @@
         "commenter": {
           "$type": "com.example.bookstore.Commenter",
           "name": "Some User",
-          "favouriteBook": "isbn:9780760768587"
+          "favouriteBook": "isbn:9780760768587",
+          "reputation": {
+            "$type": "com.example.bookstore.Reputation",
+            "booksReviewed": 10
+          }
         },
         "body": "This book is great"
       }
@@ -77,7 +81,11 @@
       "attributes": {
         "commenter": {
           "$type": "com.example.bookstore.Commenter",
-          "name": "Some Other User"
+          "name": "Some Other User",
+          "reputation": {
+            "$type": "com.example.bookstore.Reputation",
+            "booksReviewed": 8
+          }
         },
         "body": "I agree"
       }

--- a/tests/index.html
+++ b/tests/index.html
@@ -16,6 +16,13 @@
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
+
+    <style>
+      /* We don't want to see an empty white box for this test suit? */
+      #ember-testing-container {
+        display: none;
+      }
+    </style>
   </head>
   <body>
     {{content-for "body"}}

--- a/tests/integration/model-invalidation-render-test.js
+++ b/tests/integration/model-invalidation-render-test.js
@@ -57,16 +57,32 @@ module('integration/model-invalidation-render', function (hooks) {
       Customers: <span class=customers>{{bookstore.customers}}</span>
     `);
 
-    let renderedName = this.element.querySelector('.name').innerText;
-    let renderedCustomerCount = this.element.querySelector('.customers').innerText;
+    let renderedName = this.element
+      .querySelector('.name')
+      .innerText.replace(/\s+/g, ' ')
+      .replace(/^\s*/, '')
+      .replace(/\s*$/, '');
+    let renderedCustomerCount = this.element
+      .querySelector('.customers')
+      .innerText.replace(/\s+/g, ' ')
+      .replace(/^\s*/, '')
+      .replace(/\s*$/, '');
     assert.equal(renderedName, "Books 'n stuff", 'component is rendered correctly');
     assert.equal(renderedCustomerCount, '0', 'outer property rendered correctyl');
     assert.equal(this.renderCount, 1, 'initial render');
 
     run(() => bookstore.incrementProperty('customers'));
 
-    renderedName = this.element.querySelector('.name').innerText;
-    renderedCustomerCount = this.element.querySelector('.customers').innerText;
+    renderedName = this.element
+      .querySelector('.name')
+      .innerText.replace(/\s+/g, ' ')
+      .replace(/^\s*/, '')
+      .replace(/\s*$/, '');
+    renderedCustomerCount = this.element
+      .querySelector('.customers')
+      .innerText.replace(/\s+/g, ' ')
+      .replace(/^\s*/, '')
+      .replace(/\s*$/, '');
     assert.equal(renderedName, "Books 'n stuff", 'component is rendered correctly');
     assert.equal(renderedCustomerCount, '1', 'outer property rendered correctyl');
     assert.equal(this.renderCount, 1, 'rerender succeeds and does not dirty the model');

--- a/tests/pages/index.js
+++ b/tests/pages/index.js
@@ -36,15 +36,24 @@ class CommentOnPage extends PageObject {
 
 class BookOnPage extends PageObject {
   id() {
-    return this.querySelector('.id').innerText;
+    return this.querySelector('.id')
+      .innerText.replace(/\s+/g, ' ')
+      .replace(/^\s*/, '')
+      .replace(/\s*$/, '');
   }
 
   name() {
-    return this.querySelector('.name').innerText;
+    return this.querySelector('.name')
+      .innerText.replace(/\s+/g, ' ')
+      .replace(/^\s*/, '')
+      .replace(/\s*$/, '');
   }
 
   authorName() {
-    return this.querySelector('.author').innerText;
+    return this.querySelector('.author')
+      .innerText.replace(/\s+/g, ' ')
+      .replace(/^\s*/, '')
+      .replace(/\s*$/, '');
   }
 
   pubMonth() {


### PR DESCRIPTION
Hello @hjdivad finally sat down to tackle #810, this is a _proof of concept_ and would love your feedback, there's only a few failing tests but most if not all of them would be solved when we figure out the new api for the m3-schema-manager and the m3-schema

One of my main questions I guess:

Do we proceed to deprecate the `schema.models` all together? I think its not currently possible because `Model` use some of them, for instance `schema.isAttributeIncluded`

https://github.com/hjdivad/ember-m3/blob/1a3390cc9bf3bc4ef2329179bab362dae51eb9fa/addon/model.js#L283

We _could_ move these hooks to the `m3-schema` service and have some basic examples to implement the same functionality, this would mean more boilerplate... but allows more flexibility