### PR TITLE
Refactor warning capturing and testing.

### DIFF
--- a/tests/helpers/warning-handler.js
+++ b/tests/helpers/warning-handler.js
@@ -1,0 +1,27 @@
+import { registerWarnHandler } from '@ember/debug';
+
+let errorOnInternalWarnings = true;
+export let capturedWarnings = null;
+
+export function captureWarnings() {
+  capturedWarnings = [];
+  errorOnInternalWarnings = false;
+}
+
+export function resetWarnings() {
+  capturedWarnings = null;
+  errorOnInternalWarnings = true;
+}
+
+registerWarnHandler(function (message, options, next) {
+  if (options.id.includes('ember-m3')) {
+    if (errorOnInternalWarnings) {
+      throw new Error(`Unhandled Warning: ${message}`);
+    }
+
+    // gather warnings for later assertion
+    capturedWarnings.push([message, options]);
+  } else {
+    next(message, options);
+  }
+});

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -6,6 +6,9 @@ import './helpers/watch-property';
 import QUnit from 'qunit';
 import 'ember-m3/initializers/m3-store';
 
+// ensures the warning handler is setup for all tests
+import { resetWarnings } from './helpers/warning-handler';
+
 QUnit.config.urlConfig.push({
   id: 'enableoptionalfeatures',
   label: 'Enable Opt Features',
@@ -15,6 +18,8 @@ QUnit.config.urlConfig.push({
   id: 'enableproxy',
   label: 'Enable Proxy',
 });
+
+QUnit.testDone(resetWarnings);
 
 setApplication(Application.create(config.APP));
 start({

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import sinon from 'sinon';
@@ -16,6 +15,8 @@ import { isArray } from '@ember/array';
 import MegamorphicModel from 'ember-m3/model';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import require from 'require';
+
+import { capturedWarnings, captureWarnings } from '../helpers/warning-handler';
 
 const Errors = ModelErrors || StoreErrors;
 
@@ -2548,24 +2549,15 @@ for (let testRun = 0; testRun < 2; testRun++) {
       // nestedModel.unloadRecord();
       // assert.expectWarning(`Nested models cannot be directly unloaded.  Perhaps you meant to unload the top level model, 'com.example.bookstore.book:1'`);
 
-      let warnSpy = this.sinon.stub(Ember, 'warn');
+      captureWarnings();
+
       nestedModel.unloadRecord();
-      assert.deepEqual(
-        zip(
-          warnSpy.thisValues.map((x) => x + ''),
-          warnSpy.args
-        ),
+      assert.deepEqual(capturedWarnings, [
         [
-          [
-            'Ember',
-            [
-              "Nested models cannot be directly unloaded.  Perhaps you meant to unload the top level model, 'com.example.bookstore.book:1'",
-              false,
-              { id: 'ember-m3.nested-model-unloadRecord' },
-            ],
-          ],
-        ]
-      );
+          "Nested models cannot be directly unloaded.  Perhaps you meant to unload the top level model, 'com.example.bookstore.book:1'",
+          { id: 'ember-m3.nested-model-unloadRecord' },
+        ],
+      ]);
       assert.equal(
         this.store.hasRecordForId('com.example.bookstore.book', '1'),
         true,


### PR DESCRIPTION
Ember 3.27+ no longer compiles module imports down to globals, this means that when `import { warn } from '@ember/debug'` you **can no longer** stub `Ember.warn` directly and expect it to intercept the warning.

This commit introduces a new API that we can use to intercept warning invocations (leveraging `registerWarnHandler` from Ember itself), as well as ensuring that our own tests never "leak" unhandled warnings (which we didn't have a problem with, but seemed like a nice thing to add :smile:).

Fixes https://github.com/hjdivad/ember-m3/issues/1046
