### PR TITLE
Fix state notifications when CUSTOM_MODEL_CLASS is active

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -276,7 +276,7 @@ export default class MegamorphicModel extends EmberObject {
       // just super and move on for state flags
       // this needs to match whatever we are notifying
       // in our subscription to the notificationManager
-      if (['isNew', 'isDeleted'].contains(key)) {
+      if (['isNew', 'isDeleted'].indexOf(key) !== -1) {
         super.notifyPropertyChange(key);
         return;
       }

--- a/addon/model.js
+++ b/addon/model.js
@@ -272,6 +272,15 @@ export default class MegamorphicModel extends EmberObject {
   }
 
   notifyPropertyChange(key) {
+    if (CUSTOM_MODEL_CLASS) {
+      // just super and move on for state flags
+      // this needs to match whatever we are notifying
+      // in our subscription to the notificationManager
+      if (['isNew', 'isDeleted'].contains(key)) {
+        super.notifyPropertyChange(key);
+        return;
+      }
+    }
     const recordData = recordDataFor(this);
     const schemaInterface = recordData.schemaInterface;
     let resolvedKeysInCache = schemaInterface._getDependentResolvedKeys(key);


### PR DESCRIPTION
without this check and early return we take property codepaths and then blow up in `assertNoChanges` because the keys are never handled.