### PR TITLE
Avoid invalid imports in production app tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,18 @@ module.exports = {
     return this._super.treeForAddon.call(this, tree);
   },
 
+  treeForApp(tree) {
+    const isProd = process.env.EMBER_ENV === 'production';
+
+    if (isProd) {
+      tree = new Funnel(tree, {
+        exclude: ['data-adapter.js'],
+      });
+    }
+
+    return this._super.treeForApp.call(this, tree);
+  },
+
   configureBabelOptions() {
     let app = this._findHost();
 


### PR DESCRIPTION
When running in production, ember-m3 avoids emitting any modules that exit in its `addon/-infra/` and `addon/adapters/` folders.  Unfortunately, we still emit a file into the app tree that attempts to import from `ember-m3/adapters/` due to our `app/data-adapter.js` file which has a simple re-export.

This ensures that the `data-adapters.js` file is not emitted in production builds (so that it does not emit an invalid import).
