### PR TITLE
Ensure we do not add custom babel plugins multiple times

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,9 +71,18 @@ module.exports = {
 
     this.options = this.options || {};
     this.options.babel = this.options.babel || {};
-    let plugins = this.options.babel.plugins;
+    let plugins = this.options.babel.plugins ? this.options.babel.plugins.slice() : [];
     let newPlugins = getDebugMacros(app);
-    this.options.babel.plugins = Array.isArray(plugins) ? plugins.concat(newPlugins) : newPlugins;
+
+    for (let newPlugin of newPlugins) {
+      let wasPreviouslyAdded = plugins.find(
+        (existingPlugin) => Array.isArray(existingPlugin) && existingPlugin[2] === newPlugin[2]
+      );
+      if (!wasPreviouslyAdded) {
+        plugins.push(newPlugin);
+      }
+    }
+    this.options.babel.plugins = plugins;
 
     this.options.babel.loose = true;
   },


### PR DESCRIPTION
In some circumstances (e.g. while processing within Embroider's OneShot process, or when ember-m3 is a dependency of another addon) our `included` will be called multiple times and attempt to add the babel
plugins to the app each time. This results in the "duplicate preset detected" error from Babel itself.

This patch updates our plugins array mutation code to first check if our plugins have been added before adding them (preventing the error).
