### PR TITLE
feat: make errors attribute configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ the runtime cost of relationships.
 
 ### API
 
-`Schema` is a service registered from `app/services/m3-schema.js`. For convenience
+`Schema` is a service registered from `app/services/m3-schema.js`. For convenience,
 you can extend a default schema from `ember-m3/services/schema`. The `schema` should
 have following properties.
 
@@ -361,7 +361,7 @@ If you are returning a nested m3 model, return:
 If you are returning a managed array, return:
 `schemaInterface.managedArray([schemaInterface.nested(obj), someOtherValue])`
 
-If you are returning the a value you can return the raw value without passing it
+If you are returning the value you can return the raw value without passing it
 through the schemaInterface call
 
 For example, if we have a book object:
@@ -501,6 +501,10 @@ and `bestChapter` a nested m3 model and not a simple object.
       }
     }
     ```
+
+- `useUnderlyingErrorsValue(modelName)` Helps the `model.js` determine whether to treat the `errors` attribute
+  should be read from the underlying data payload. The default return is false which creates an object compatible with
+  how Ember Data treats `errors` property. Return true to read from the data payload for the model.
 
 ## Serializer / Adapter
 

--- a/addon/model.js
+++ b/addon/model.js
@@ -641,7 +641,9 @@ export default class MegamorphicModel extends EmberObject {
   // Errors hash that will get update,
   // upon validation errors
   get errors() {
-    if (this._errors === null) {
+    if (this._schema.useUnderlyingErrorsValue(this._modelName)) {
+      return this.unknownProperty('errors');
+    } else if (this._errors === null) {
       this._errors = Errors.create();
     }
     return this._errors;

--- a/addon/services/m3-schema-manager.js
+++ b/addon/services/m3-schema-manager.js
@@ -57,6 +57,17 @@ export default class SchemaManager extends Service {
   }
 
   /**
+   * Calls the schema's useUnderlyingErrorsValue passing in modelName
+   *
+   * @param {string} modelName - Name of model to determine if `errors` property in the payload should be used
+   * @returns {boolean}
+   */
+  useUnderlyingErrorsValue(modelName) {
+    let schema = this.get('schema');
+    return schema.useUnderlyingErrorsValue(modelName);
+  }
+
+  /**
    * Whether or not ember-m3 should handle this `modelName`.
    *
    * @param {string} modelName

--- a/addon/services/m3-schema.js
+++ b/addon/services/m3-schema.js
@@ -103,6 +103,18 @@ export default class DefaultSchema extends Service {
     }
   }
 
+  /**
+   * Default return value to false. This is for child classes to override.
+   *
+   * `modelName` parameter is passed to this but removed to pass eslint linting rule
+   *
+   * @param {string} modelName - Name of model to determine if `errors` property in the payload should be used
+   * @returns {boolean}
+   */
+  useUnderlyingErrorsValue() {
+    return false;
+  }
+
   /*
     models: {
       'my-model-name': {

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -1,0 +1,155 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { run } from '@ember/runloop';
+import { get } from '@ember/object';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+import { Errors as ModelErrors } from '@ember-data/model/-private';
+
+class TestSchemaFlagOn extends DefaultSchema {
+  includesModel(modelName) {
+    return /^com.example.bookstore\./i.test(modelName);
+  }
+
+  useUnderlyingErrorsValue() {
+    return true;
+  }
+}
+
+class TestSchemaFlagOff extends DefaultSchema {
+  includesModel(modelName) {
+    return /^com.example.bookstore\./i.test(modelName);
+  }
+
+  useUnderlyingErrorsValue() {
+    return false;
+  }
+}
+
+class TestSchemaNoOverride extends DefaultSchema {
+  includesModel(modelName) {
+    return /^com.example.bookstore\./i.test(modelName);
+  }
+}
+
+const errorsArray = [
+  {
+    path: ['talentHiringProjectsByCriteria'],
+    locations: [{ column: 3, line: 2 }],
+    message: 'Error calling findByCriteria.',
+  },
+];
+
+module('unit/model/errors-attribute', function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('schema with flag set to true returns errors from payload', function (assert) {
+    this.owner.register('service:m3-schema', TestSchemaFlagOn);
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'urn:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            author: ['urn:author:1'],
+            errors: errorsArray,
+          },
+        },
+      });
+    });
+    assert.deepEqual(
+      get(model, 'errors').get('firstObject'),
+      errorsArray[0],
+      "schema's useUnderlyingErrorsValue value set to true should return payload errors array"
+    );
+  });
+
+  test('schema with flag set to true but no errors in payload returns undefined', function (assert) {
+    this.owner.register('service:m3-schema', TestSchemaFlagOn);
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'urn:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            author: ['urn:author:1'],
+          },
+        },
+      });
+    });
+    assert.equal(
+      get(model, 'errors'),
+      undefined,
+      "schema's useUnderlyingErrorsValue returns true but missing data payload should return undefined"
+    );
+  });
+
+  test('schema with flag set to true returns errors from payload', function (assert) {
+    this.owner.register('service:m3-schema', TestSchemaFlagOn);
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'urn:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            author: ['urn:author:1'],
+            errors: errorsArray,
+          },
+        },
+      });
+    });
+    assert.deepEqual(
+      get(model, 'errors').get('firstObject'),
+      errorsArray[0],
+      "schema's useUnderlyingErrorsValue returns true should return payload errors array"
+    );
+  });
+
+  test('schema with flag set to false returns Errors object instance', function (assert) {
+    this.owner.register('service:m3-schema', TestSchemaFlagOff);
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'urn:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            author: ['urn:author:1'],
+            errors: errorsArray,
+          },
+        },
+      });
+    });
+    assert.ok(
+      get(model, 'errors') instanceof ModelErrors,
+      "schema's useUnderlyingErrorsValue returns false should return ModelsError object instance"
+    );
+  });
+
+  test('schema with no flag property returns Errors object instance', function (assert) {
+    this.owner.register('service:m3-schema', TestSchemaNoOverride);
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'urn:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            author: ['urn:author:1'],
+            errors: errorsArray,
+          },
+        },
+      });
+    });
+    assert.ok(
+      get(model, 'errors') instanceof ModelErrors,
+      "schema's default useUnderlyingErrorsValue return value should return ModelsError object instance"
+    );
+  });
+});

--- a/tests/unit/schema-manager-test.js
+++ b/tests/unit/schema-manager-test.js
@@ -216,4 +216,41 @@ module('unit/schema-manager', function (hooks) {
     );
     assert.equal(this.schemaManager.useComputeAttribute(), true);
   });
+
+  test("schema's useUnderlyingErrorsValue returns true", function (assert) {
+    this.registerSchema(
+      class TestSchema extends DefaultSchema {
+        useUnderlyingErrorsValue(modelName) {
+          assert.equal(
+            modelName,
+            'com.example.bookstore.Book',
+            "model name is passed to schema's useUnderlyingErrorsValue function"
+          );
+          return true;
+        }
+      }
+    );
+    assert.equal(this.schemaManager.useUnderlyingErrorsValue('com.example.bookstore.Book'), true);
+  });
+
+  test("schema's useUnderlyingErrorsValue returns false", function (assert) {
+    this.registerSchema(
+      class TestSchema extends DefaultSchema {
+        useUnderlyingErrorsValue(modelName) {
+          assert.equal(
+            modelName,
+            'com.example.bookstore.Book',
+            "model name is passed to schema's useUnderlyingErrorsValue function"
+          );
+          return false;
+        }
+      }
+    );
+    assert.equal(this.schemaManager.useUnderlyingErrorsValue('com.example.bookstore.Book'), false);
+  });
+
+  test("schema's default useUnderlyingErrorsValue function call as false", function (assert) {
+    this.registerSchema(DefaultSchema);
+    assert.equal(this.schemaManager.useUnderlyingErrorsValue(), false);
+  });
 });


### PR DESCRIPTION
Adding the ability to configure whether to read from underlying data's `errors` attribute if it exists