### PR TITLE
Allow custom ObjectProxy instances to be wrapped around an M3Model instance 

### DIFF
--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -2,6 +2,7 @@ import { dasherize } from '@ember/string';
 import { recordDataFor } from './-private';
 import { EmbeddedMegamorphicModel, EmbeddedSnapshot } from './model';
 import { A } from '@ember/array';
+import { get } from '@ember/object';
 import ManagedArray from './managed-array';
 import { schemaTypesInfo, NESTED, REFERENCE, MANAGED_ARRAY } from './utils/schema-types-info';
 import {
@@ -215,7 +216,7 @@ function resolveManagedArray(content, key, value, modelName, store, schema, reco
       record,
     });
     array._setInternalModels(
-      content.map((c) => c._internalModel || c),
+      content.map((c) => get(c, '_internalModel') || c),
       false
     );
     return array;

--- a/tests/unit/model/tracked-array-test.js
+++ b/tests/unit/model/tracked-array-test.js
@@ -339,6 +339,9 @@ for (let testRun = 0; testRun < 2; testRun++) {
         assert.equal(objectAt, A(chapters).objectAt, 'Ember.A doesnt modify ember array methods');
       });
 
+      // We have found instances in the wild of users wrapping models in an ember object proxy and returning
+      // those as array members from schema hooks. While not recommneded and bound to go away in modern ember, this test asserts
+      // that we do not accidentally trigger the object proxy property access assertions.
       test('ember proxy objects can be pushed into nested arrays', function (assert) {
         this.schema = this.owner.lookup('service:m3-schema');
 

--- a/tests/unit/model/tracked-array-test.js
+++ b/tests/unit/model/tracked-array-test.js
@@ -6,6 +6,7 @@ import { setupTest } from 'ember-qunit';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import { A } from '@ember/array';
 import ManagedArray from 'ember-m3/managed-array';
+import ObjectProxy from '@ember/object/proxy';
 
 function computeNestedModel(key, value /*, modelName, schemaInterface */) {
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
@@ -336,6 +337,52 @@ for (let testRun = 0; testRun < 2; testRun++) {
         assert.equal(chapters, A(chapters), 'Ember.A doesnt replace the tracked array');
         assert.equal(push, A(chapters).push, 'Ember.A doesnt modify native array methods');
         assert.equal(objectAt, A(chapters).objectAt, 'Ember.A doesnt modify ember array methods');
+      });
+
+      test('ember proxy objects can be pushed into nested arrays', function (assert) {
+        this.schema = this.owner.lookup('service:m3-schema');
+
+        let chapter = this.store.push({
+          data: {
+            id: 'chapter',
+            type: 'com.example.bookstore.Chapter',
+            attributes: {
+              name: `Chapter 1`,
+            },
+          },
+        });
+        this.schema.computeAttribute = (key, value, modelName, schemaInterface) => {
+          if (value instanceof Array) {
+            return schemaInterface.managedArray([
+              ObjectProxy.create({
+                content: chapter,
+              }),
+            ]);
+          } else {
+            return value;
+          }
+        };
+
+        let book = this.store.push({
+          data: {
+            id: 'isbn:9780439708180',
+            type: 'com.example.bookstore.Book',
+            attributes: {
+              name: `Harry Potter and the Sorcerer's Stone`,
+              chapters: [
+                {
+                  name: 'The Boy Who Lived',
+                },
+              ],
+            },
+          },
+        });
+
+        assert.strictEqual(
+          book.get('chapters').objectAt(0).get('name'),
+          'Chapter 1',
+          'Returning an object proxy as a member of a managed array does not error out'
+        );
       });
     }
   );


### PR DESCRIPTION
We discovered instances in the wild of users wrapping models in an ember object proxy and returning those from schema hooks. https://github.com/hjdivad/ember-m3/pull/789 broke some of those use cases, by accessing `_internalModel` in all of the array creation flows, thus triggering Ember's object proxy property access assertion. This is a temporary fix for that behavior, which goes away in the custom model class branch.