### PR TITLE
Increase iterations in materialization perf test to decrease noise

### DIFF
--- a/m3-perf-testing-app/app/routes/materializing.js
+++ b/m3-perf-testing-app/app/routes/materializing.js
@@ -2,11 +2,15 @@ import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import generateSampleData from '../models/sample-data';
 
+const iterations = 8000;
+
 export default class Materializing extends Route {
   model() {
-    let sampleData = [...Array(3000)].map((e, i) => generateSampleData(i));
+    let sampleData = [...Array(iterations)].map((e, i) =>
+      generateSampleData(i)
+    );
     performance.mark('start-loading');
-    for (let i = 0; i < 3000; i++) {
+    for (let i = 0; i < iterations; i++) {
       this.store.pushPayload(
         'com.example.bookstore.search-results',
         sampleData[i]

--- a/m3-perf-testing-app/app/routes/materializing.js
+++ b/m3-perf-testing-app/app/routes/materializing.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import generateSampleData from '../models/sample-data';
 
-const iterations = 8000;
+const iterations = 12000;
 
 export default class Materializing extends Route {
   model() {

--- a/m3-perf-testing-app/testem.js
+++ b/m3-perf-testing-app/testem.js
@@ -6,6 +6,7 @@ module.exports = {
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
+  browser_disconnect_timeout: 60,
   browser_args: {
     Chrome: {
       ci: [

--- a/m3-perf-testing-app/tests/acceptance/materializing-test.js
+++ b/m3-perf-testing-app/tests/acceptance/materializing-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
-const iterations = 8000;
+const iterations = 12000;
 
 module('Acceptance | materializing', function (hooks) {
   setupApplicationTest(hooks);
@@ -13,7 +13,11 @@ module('Acceptance | materializing', function (hooks) {
     assert.equal(currentURL(), '/materializing');
     let store = this.owner.lookup('service:store');
     let searches = store.peekAll('com.example.bookstore.SearchResults');
-    assert.equal(searches.length, iterations, 'generated 1000 sample payloads');
+    assert.equal(
+      searches.length,
+      iterations,
+      `generated ${iterations} sample payloads`
+    );
     searches.forEach((search) => {
       let results = search.get('results');
       assert.equal(results.length, 4, 'there are four results');

--- a/m3-perf-testing-app/tests/acceptance/materializing-test.js
+++ b/m3-perf-testing-app/tests/acceptance/materializing-test.js
@@ -2,6 +2,8 @@ import { module, test } from 'qunit';
 import { visit, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 
+const iterations = 8000;
+
 module('Acceptance | materializing', function (hooks) {
   setupApplicationTest(hooks);
 
@@ -11,7 +13,7 @@ module('Acceptance | materializing', function (hooks) {
     assert.equal(currentURL(), '/materializing');
     let store = this.owner.lookup('service:store');
     let searches = store.peekAll('com.example.bookstore.SearchResults');
-    assert.equal(searches.length, 3000, 'generated 1000 sample payloads');
+    assert.equal(searches.length, iterations, 'generated 1000 sample payloads');
     searches.forEach((search) => {
       let results = search.get('results');
       assert.equal(results.length, 4, 'there are four results');

--- a/m3-perf-testing-app/tests/acceptance/materializing-test.js
+++ b/m3-perf-testing-app/tests/acceptance/materializing-test.js
@@ -18,7 +18,12 @@ module('Acceptance | materializing', function (hooks) {
       iterations,
       `generated ${iterations} sample payloads`
     );
-    searches.forEach((search) => {
+    searches.forEach((search, i) => {
+      // Sample the array for correctness, otherwise the test generates too
+      // many assertions and take too long
+      if (i % 50 !== 0) {
+        return;
+      }
       let results = search.get('results');
       assert.equal(results.length, 4, 'there are four results');
       assert.deepEqual(


### PR DESCRIPTION
Running https://github.com/hjdivad/ember-m3/pull/1157 shows that the materialization test is somewhat noisy, increasing the number of iterations to decrease noise