### PR TITLE
Custom Model Classes: Ensure isDirty for embedded records doesn't recursively loop

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -243,7 +243,6 @@ export default class MegamorphicModel extends EmberObject {
 
   _updateCurrentState(state) {
     if (CUSTOM_MODEL_CLASS) {
-      notifyPropertyChange(this, 'isDirty');
       notifyPropertyChange(this, 'isDeleted');
       notifyPropertyChange(this, 'isNew');
       // TODO need to walk the chain down as well to notify changes
@@ -251,6 +250,12 @@ export default class MegamorphicModel extends EmberObject {
     if (this !== this._topModel) {
       this._topModel._updateCurrentState(!CUSTOM_MODEL_CLASS && state);
       return;
+    }
+
+    // isDirty for embedded models depends on the parent state
+    // se we only notify changes for top level models
+    if (CUSTOM_MODEL_CLASS) {
+      notifyPropertyChange(this, 'isDirty');
     }
     // assert we don't need this anymore
     if (!CUSTOM_MODEL_CLASS) {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -32,8 +32,8 @@ module.exports = function () {
           name: 'ember-lts-n-1',
           npm: {
             devDependencies: {
-              'ember-source': '~3.20.0',
-              'ember-data': '~3.20.0',
+              'ember-source': '~3.12.0',
+              'ember-data': '~3.16.0',
               '@ember-data/store': null,
               '@ember-data/debug': null,
               '@ember-data/model': null,
@@ -48,8 +48,8 @@ module.exports = function () {
           name: 'ember-lts',
           npm: {
             devDependencies: {
-              'ember-source': '~3.24.0',
-              'ember-data': '~3.24.0',
+              'ember-source': '~3.16.0',
+              'ember-data': '~3.16.0',
               '@ember-data/store': null,
               '@ember-data/debug': null,
               '@ember-data/model': null,

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "broccoli-funnel": "^3.0.8",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-version-checker": "^5.1.2",
-    "ember-compatibility-helpers": "^1.2.4",
     "semver": "^7.3.5"
   },
   "devDependencies": {
@@ -86,6 +85,7 @@
     "ember-cli-shims": "^1.1.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^3.0.0",
+    "ember-compatibility-helpers": "^1.2.4",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.1",
     "ember-inflector": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "broccoli-funnel": "^3.0.8",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-version-checker": "^5.1.2",
+    "ember-compatibility-helpers": "^1.2.4",
     "semver": "^7.3.5"
   },
   "devDependencies": {

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -5,9 +5,7 @@ import { isArray } from '@ember/array';
 import Component from '@ember/component';
 import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@ember/test-helpers';
-import {
-  gte
-} from 'ember-compatibility-helpers';
+import { gte } from 'ember-compatibility-helpers';
 
 import DefaultSchema from 'ember-m3/services/m3-schema';
 

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -3,7 +3,7 @@ import { setupTest, setupRenderingTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
 import { isArray } from '@ember/array';
 import Component from '@ember/component';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { render } from '@ember/test-helpers';
 import {
   gte

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -232,15 +232,15 @@ for (let testRun = 0; testRun < 2; testRun++) {
   );
 }
 
-module('unit/model/state with rendering', function (hooks) {
-  setupRenderingTest(hooks);
+if (gte('3.24.0')) {
+  module('unit/model/state with rendering', function (hooks) {
+    setupRenderingTest(hooks);
 
-  hooks.beforeEach(function () {
-    this.owner.register('service:m3-schema', TestSchema);
-    this.store = this.owner.lookup('service:store');
-  });
+    hooks.beforeEach(function () {
+      this.owner.register('service:m3-schema', TestSchema);
+      this.store = this.owner.lookup('service:store');
+    });
 
-  if (gte('3.24.0')) {
     test('updating isDirty flag does not cause rerenders', async function (assert) {
       this.owner.register(
         'component:show-dirtyness',
@@ -281,5 +281,5 @@ module('unit/model/state with rendering', function (hooks) {
 
       assert.equal(this.element.innerText, 'Book is dirty', 'Book renders as dirty');
     });
-  }
-});
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5625,7 +5625,7 @@ ember-cli@~3.26.1:
     workerpool "^6.0.3"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1:
+ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz#70e0fef7048969141626eed6006f3880df612cd1"
   integrity sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==


### PR DESCRIPTION
With Custom Model Class, we were notifying property changes for `isDirty`  on embedded models, which normally depend on their parents `isDirty` state, causing a loop.