### PR TITLE
Make materializing route in perf app configurable

### DIFF
--- a/.github/workflows/perf-check.yml
+++ b/.github/workflows/perf-check.yml
@@ -36,8 +36,8 @@ jobs:
           scenarios: |
             {
               "materializing": {
-                "control": "http://localhost:4200/materializing",
-                "experiment": "http://localhost:4201/materializing",
+                "control": "http://localhost:4200/materializing/12000",
+                "experiment": "http://localhost:4201/materializing/12000",
                 "markers": "start-loading,pushed-payload,end-loading"
               },
               "rendering": {

--- a/m3-perf-testing-app/app/router.js
+++ b/m3-perf-testing-app/app/router.js
@@ -8,5 +8,5 @@ export default class Router extends EmberRouter {
 
 Router.map(function () {
   this.route('rendering');
-  this.route('materializing');
+  this.route('materializing', { path: '/materializing/:count' });
 });

--- a/m3-perf-testing-app/app/routes/materializing.js
+++ b/m3-perf-testing-app/app/routes/materializing.js
@@ -2,10 +2,9 @@ import Route from '@ember/routing/route';
 import { action } from '@ember/object';
 import generateSampleData from '../models/sample-data';
 
-const iterations = 12000;
-
 export default class Materializing extends Route {
-  model() {
+  model(params) {
+    let iterations = parseInt(params.count);
     let sampleData = [...Array(iterations)].map((e, i) =>
       generateSampleData(i)
     );

--- a/m3-perf-testing-app/tests/acceptance/materializing-test.js
+++ b/m3-perf-testing-app/tests/acceptance/materializing-test.js
@@ -1,29 +1,18 @@
 import { module, test } from 'qunit';
-import { visit, currentURL } from '@ember/test-helpers';
+import { visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-
-const iterations = 12000;
 
 module('Acceptance | materializing', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting /materializing', async function (assert) {
-    await visit('/materializing');
+    await visit('/materializing/50');
 
-    assert.equal(currentURL(), '/materializing');
     let store = this.owner.lookup('service:store');
     let searches = store.peekAll('com.example.bookstore.SearchResults');
-    assert.equal(
-      searches.length,
-      iterations,
-      `generated ${iterations} sample payloads`
-    );
-    searches.forEach((search, i) => {
-      // Sample the array for correctness, otherwise the test generates too
-      // many assertions and take too long
-      if (i % 1000 !== 0) {
-        return;
-      }
+    assert.equal(searches.length, 50, `generated 50 sample payloads`);
+    for (let i = 0; i < 50; i++) {
+      let search = searches.objectAt(i);
       let results = search.get('results');
       assert.equal(results.length, 4, 'there are four results');
       assert.deepEqual(
@@ -46,6 +35,6 @@ module('Acceptance | materializing', function (hooks) {
         'This book is great,I agree,,,Yup,',
         'correct reader comments'
       );
-    });
+    }
   });
 });


### PR DESCRIPTION
Perf app tests were timing out on CI, as running dev builds on CI containers was too slow, causing testem to time out while the records were being materialized. Now for testing the perf app, we materialize fewer records.