### PR TITLE
fix: skip this.errors.remove if useUnderlyingErrorsValue

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -645,8 +645,15 @@ export default class MegamorphicModel extends EmberObject {
   }
 
   _removeError(key) {
+    // Skip if `useUnderlyingErrorsValue` returns true meaning we are treating `errors` as an
+    // attribute from the payload
+    if (this._schema.useUnderlyingErrorsValue(this._modelName)) {
+      return;
+    }
+
     // Remove errors for the property
     this.errors.remove(key);
+
     if (CUSTOM_MODEL_CLASS) {
       if (get(this.errors, 'length') === 0) {
         this._clearInvalidRequestErrors();

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -1,12 +1,9 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
-import EmberObject, { get, set, computed } from '@ember/object';
+import { get } from '@ember/object';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import { Errors as ModelErrors } from '@ember-data/model/-private';
-import { Errors as StoreErrors } from '@ember-data/store/-private';
-
-const Errors = ModelErrors || StoreErrors;
 
 class TestSchemaFlagOn extends DefaultSchema {
   includesModel(modelName) {

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -173,7 +173,7 @@ module('unit/model/errors-attribute', function (hooks) {
     });
     const getErrorsSpy = this.sinon.spy(model, 'errors', ['get']);
     model._removeError('author');
-    assert.equal(getErrorsSpy.get.callCount, 1, 'get errors is called');
+    assert.ok(getErrorsSpy.get.callCount > 0, 'get errors is called');
   });
 
   test('schema with no flag property returns Errors object instance', function (assert) {

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -104,13 +104,14 @@ module('unit/model/errors-attribute', function (hooks) {
           id: 'urn:book:1',
           type: 'com.example.bookstore.Book',
           attributes: {
-            author: ['urn:author:1'],
+            title: 'Goblins',
           },
         },
       });
     });
     const getErrorsSpy = this.sinon.spy(model, 'errors', ['get']);
-    model._removeError('author');
+    // `setUnknownProperty` calls `_removeError` which calls `this.errors`
+    model.setUnknownProperty('title', 'Harry Potter');
     assert.equal(getErrorsSpy.get.callCount, 0, 'get errors is not called');
   });
 
@@ -166,13 +167,14 @@ module('unit/model/errors-attribute', function (hooks) {
           id: 'urn:book:1',
           type: 'com.example.bookstore.Book',
           attributes: {
-            author: ['urn:author:1'],
+            title: 'Goblins',
           },
         },
       });
     });
     const getErrorsSpy = this.sinon.spy(model, 'errors', ['get']);
-    model._removeError('author');
+    // `setUnknownProperty` calls `_removeError` which calls `this.errors`
+    model.setUnknownProperty('title', 'Harry Potter');
     assert.ok(getErrorsSpy.get.callCount > 0, 'get errors is called');
   });
 

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -1,10 +1,12 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
-import { get } from '@ember/object';
+import EmberObject, { get, set, computed } from '@ember/object';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import { Errors as ModelErrors } from '@ember-data/model/-private';
-import sinon from 'sinon';
+import { Errors as StoreErrors } from '@ember-data/store/-private';
+
+const Errors = ModelErrors || StoreErrors;
 
 class TestSchemaFlagOn extends DefaultSchema {
   includesModel(modelName) {
@@ -44,12 +46,7 @@ module('unit/model/errors-attribute', function (hooks) {
   setupTest(hooks);
 
   hooks.beforeEach(function () {
-    this.sinon = sinon.createSandbox();
     this.store = this.owner.lookup('service:store');
-  });
-
-  hooks.afterEach(function () {
-    this.sinon.restore();
   });
 
   test('schema with flag set to true returns errors from payload', function (assert) {
@@ -62,6 +59,7 @@ module('unit/model/errors-attribute', function (hooks) {
           type: 'com.example.bookstore.Book',
           attributes: {
             author: ['urn:author:1'],
+            title: 'Harry Potter',
             errors: errorsArray,
           },
         },
@@ -71,6 +69,14 @@ module('unit/model/errors-attribute', function (hooks) {
       get(model, 'errors').get('firstObject'),
       errorsArray[0],
       "schema's useUnderlyingErrorsValue value set to true should return payload errors array"
+    );
+
+    model.set('title', 'Goblin');
+
+    assert.deepEqual(
+      get(model, 'errors').get('firstObject'),
+      errorsArray[0],
+      'errors should still be accessible after setting a property'
     );
   });
 
@@ -93,26 +99,6 @@ module('unit/model/errors-attribute', function (hooks) {
       undefined,
       "schema's useUnderlyingErrorsValue returns true but missing data payload should return undefined"
     );
-  });
-
-  test('schema with flag set to true causes _removeError to be a noop', function (assert) {
-    this.owner.register('service:m3-schema', TestSchemaFlagOn);
-
-    let model = run(() => {
-      return this.store.push({
-        data: {
-          id: 'urn:book:1',
-          type: 'com.example.bookstore.Book',
-          attributes: {
-            title: 'Goblins',
-          },
-        },
-      });
-    });
-    const getErrorsSpy = this.sinon.spy(model, 'errors', ['get']);
-    // `setUnknownProperty` calls `_removeError` which calls `this.errors`
-    model.setUnknownProperty('title', 'Harry Potter');
-    assert.equal(getErrorsSpy.get.callCount, 0, 'get errors is not called');
   });
 
   test('schema with flag set to true returns errors from payload', function (assert) {
@@ -156,26 +142,6 @@ module('unit/model/errors-attribute', function (hooks) {
       get(model, 'errors') instanceof ModelErrors,
       "schema's useUnderlyingErrorsValue returns false should return ModelsError object instance"
     );
-  });
-
-  test('schema with flag set to false causes _removeError to not be skipped', function (assert) {
-    this.owner.register('service:m3-schema', TestSchemaFlagOff);
-
-    let model = run(() => {
-      return this.store.push({
-        data: {
-          id: 'urn:book:1',
-          type: 'com.example.bookstore.Book',
-          attributes: {
-            title: 'Goblins',
-          },
-        },
-      });
-    });
-    const getErrorsSpy = this.sinon.spy(model, 'errors', ['get']);
-    // `setUnknownProperty` calls `_removeError` which calls `this.errors`
-    model.setUnknownProperty('title', 'Harry Potter');
-    assert.ok(getErrorsSpy.get.callCount > 0, 'get errors is called');
   });
 
   test('schema with no flag property returns Errors object instance', function (assert) {


### PR DESCRIPTION
Skip the code flow for `_removeError ` if `this._schema.useUnderlyingErrorsValue(this._modelName)` returns true