### PR TITLE
Fix isDirty for inflight records and set _topModel to the proxy value

### DIFF
--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -157,6 +157,7 @@ export default class M3Store extends Store {
         if (value === 'state') {
           record.notifyPropertyChange('isNew');
           record.notifyPropertyChange('isDeleted');
+          record.notifyPropertyChange('isDirty');
         } else if (value === 'identity') {
           record.notifyPropertyChange('id');
         }


### PR DESCRIPTION
In CUSTOM_MODEL_CLASS branches, we were not triggering the `isDirty` notification when the record had been saved.
Also, because we rely on object identity of `_topModel`, we need to account for potential proxy values that could be wrapping the Megamorphic model, so now we set '_topModel' after we instantiate the MegamorphicModel instance.