### PR TITLE
Add support for tracked properties with proxied managed array

### DIFF
--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -112,6 +112,8 @@ if (CUSTOM_MODEL_CLASS) {
     }
 
     objectAt(idx) {
+      // Need to get '[]' in order to entangle tracked properties, as ember won't treat us as an ember array when we are a proxy
+      // See https://github.com/emberjs/ember.js/issues/19139#issuecomment-694487616 for context
       get(this, '[]');
       this._resolve();
       // TODO make this lazy again
@@ -211,6 +213,8 @@ if (CUSTOM_MODEL_CLASS) {
     }
 
     get length() {
+      // Need to get '[]' in order to entangle tracked properties, as ember won't treat us as an ember array when we are a proxy
+      // See https://github.com/emberjs/ember.js/issues/19139#issuecomment-694487616 for context
       get(this, '[]');
       return this._resolved ? this._objects.length : this._references.length;
     }

--- a/addon/model.js
+++ b/addon/model.js
@@ -149,7 +149,7 @@ if (CUSTOM_MODEL_CLASS) {
 // If a value returned from unknownProperty is a ManagedArray we need to access '[]'
 // to keep parity with how ember treats arrays
 // see https://github.com/emberjs/ember.js/blob/3ce13cea235cde8a87d89473533c453523412764/packages/%40ember/-internals/metal/lib/property_get.ts#L136
-function accessBracketsIfArray(maybeArray) {
+function readCachedValue(maybeArray) {
   if (MANAGED_ARRAYS.has(maybeArray)) {
     get(maybeArray, '[]');
   }
@@ -505,7 +505,7 @@ export default class MegamorphicModel extends EmberObject {
 
   unknownProperty(key) {
     if (key in this._cache) {
-      return accessBracketsIfArray(this._cache[key]);
+      return readCachedValue(this._cache[key]);
     }
 
     if (!this._schema.isAttributeIncluded(this._modelName, key)) {
@@ -527,12 +527,12 @@ export default class MegamorphicModel extends EmberObject {
 
       // If default value is not defined, resolve the key for reference
       if (defaultValue !== undefined) {
-        return accessBracketsIfArray((this._cache[key] = defaultValue));
+        return readCachedValue((this._cache[key] = defaultValue));
       }
     }
 
     let value = this._schema.transformValue(this._modelName, key, rawValue);
-    return accessBracketsIfArray(
+    return readCachedValue(
       (this._cache[key] = resolveValue(
         key,
         value,

--- a/tests/integration/managed-array-tracked-test.js
+++ b/tests/integration/managed-array-tracked-test.js
@@ -1,0 +1,303 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, settled } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+import Component from '@ember/component';
+import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
+
+if (CUSTOM_MODEL_CLASS) {
+  module('integration/managed-array-tracked', function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.owner.register(
+        'service:m3-schema',
+        class TestSchema extends DefaultSchema {
+          useNativeProperties() {
+            return true;
+          }
+          computeAttribute(key, value, modelName, schemaInterface) {
+            let refValue = schemaInterface.getAttr(`*${key}`);
+            if (typeof refValue === 'string') {
+              return schemaInterface.reference({
+                type: null,
+                id: refValue,
+              });
+            } else if (Array.isArray(refValue)) {
+              return schemaInterface.managedArray(
+                refValue.map((id) =>
+                  schemaInterface.reference({
+                    type: null,
+                    id,
+                  })
+                )
+              );
+            } else if (typeof value === 'object') {
+              return schemaInterface.nested({ attributes: value });
+            }
+
+            return value;
+          }
+          includesModel(modelName) {
+            return /^com\.example\./.test(modelName);
+          }
+        }
+      );
+      this.store = this.owner.lookup('service:store');
+    });
+
+    test('mutating reference arrays cause re-renders', async function (assert) {
+      this.store.push({
+        data: {
+          id: 'urn:bookstore:1',
+          type: 'com.example.Bookstore',
+          attributes: {
+            '*books': ['urn:book:1', 'urn:book:2'],
+          },
+        },
+        included: [
+          {
+            id: 'urn:book:1',
+            type: 'com.example.Book',
+            attributes: {
+              author: {
+                name: 'Edward Gibbons',
+              },
+            },
+          },
+          {
+            id: 'urn:book:2',
+            type: 'com.example.Book',
+            attributes: {
+              author: {
+                name: 'Winston Churchill',
+              },
+            },
+          },
+          {
+            id: 'urn:book:3',
+            type: 'com.example.Book',
+            attributes: {
+              author: {
+                name: 'George R. R. Martin',
+              },
+            },
+          },
+        ],
+      });
+      this.owner.register(
+        'component:first-book',
+        class FirstBookComponent extends Component {
+          get firstBook() {
+            return this.bookstore.books[0];
+          }
+        }
+      );
+      this.owner.register(
+        'template:components/first-book',
+        hbs`<h1>{{this.firstBook.author.name}}</h1>
+      `
+      );
+
+      let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
+      let books = bookstore.books;
+
+      this.set('bookstore', bookstore);
+      await render(hbs`
+    {{first-book bookstore=this.bookstore}}
+  `);
+
+      let renderedAuthor = this.element.querySelector('h1');
+      assert.equal(
+        renderedAuthor.innerText,
+        'Edward Gibbons',
+        'Started with the correct book in position 0'
+      );
+
+      books.shift();
+      await settled();
+      renderedAuthor = this.element.querySelector('h1');
+      assert.equal(
+        renderedAuthor.innerText,
+        'Winston Churchill',
+        'Recomputed the first book after removal'
+      );
+
+      await settled(books.unshift(this.store.peekRecord('com.example.Book', 'urn:book:3')));
+
+      renderedAuthor = this.element.querySelector('h1');
+      assert.equal(
+        renderedAuthor.innerText,
+        'George R. R. Martin',
+        'Recomputed the first book after addition'
+      );
+    });
+
+    test('mutating arrays causes length tracked properties to recompute', async function (assert) {
+      this.store.pushPayload('com.example.Bookstore', {
+        data: {
+          id: 'urn:bookstore:1',
+          type: 'com.example.Bookstore',
+          attributes: {
+            // initially no books
+            '*books': [],
+          },
+        },
+        included: [
+          {
+            id: 'urn:book:1',
+            type: 'com.example.Book',
+            author: {
+              name: 'Edward Gibbons',
+            },
+          },
+          {
+            id: 'urn:book:2',
+            type: 'com.example.Book',
+            author: {
+              name: 'Winston Churchill',
+            },
+          },
+          {
+            id: 'urn:book:3',
+            type: 'com.example.Book',
+            attributes: {
+              author: {
+                name: 'George R. R. Martin',
+              },
+            },
+          },
+        ],
+      });
+
+      let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
+      let books = bookstore.get('books');
+      this.owner.register(
+        'component:x-foo',
+        class XFooComponent extends Component {
+          get hasAnything() {
+            return this.bookstore.books.length > 0;
+          }
+        }
+      );
+      this.owner.register(
+        'template:components/x-foo',
+        hbs`
+        {{#if this.hasAnything}}
+          Has Content
+        {{else}}
+          Empty
+        {{/if}}
+    `
+      );
+
+      this.set('bookstore', bookstore);
+
+      assert.equal(books.length, 0, 'initial books.length');
+      await render(hbs`
+      {{x-foo bookstore=this.bookstore}}
+    `);
+
+      let text = this.element.textContent.trim();
+      assert.equal(text, 'Empty', 'initially length == 0');
+
+      this.store.pushPayload('com.example.Bookstore', {
+        data: {
+          id: 'urn:bookstore:1',
+          type: 'com.example.Bookstore',
+          attributes: {
+            '*books': ['urn:book:1', 'urn:book:2'],
+          },
+        },
+      });
+
+      await settled();
+      assert.equal(books.length, 2, 'updated books.length');
+      text = this.element.textContent.trim();
+      assert.equal(text, 'Has Content', 'length updated');
+    });
+
+    test('mutating arrays causes properties which accessed the array to recompute', async function (assert) {
+      this.store.pushPayload('com.example.Bookstore', {
+        data: {
+          id: 'urn:bookstore:1',
+          type: 'com.example.Bookstore',
+          attributes: {
+            // initially no books
+            '*books': [],
+          },
+        },
+        included: [
+          {
+            id: 'urn:book:1',
+            type: 'com.example.Book',
+            author: {
+              name: 'Edward Gibbons',
+            },
+          },
+          {
+            id: 'urn:book:2',
+            type: 'com.example.Book',
+            author: {
+              name: 'Winston Churchill',
+            },
+          },
+          {
+            id: 'urn:book:3',
+            type: 'com.example.Book',
+            attributes: {
+              author: {
+                name: 'George R. R. Martin',
+              },
+            },
+          },
+        ],
+      });
+
+      let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
+      let books = bookstore.get('books');
+      let count = 0;
+      this.owner.register(
+        'component:x-foo',
+        class XFooComponent extends Component {
+          get numberOfRenders() {
+            this.bookstore.books;
+            count++;
+            return count;
+          }
+        }
+      );
+      this.owner.register(
+        'template:components/x-foo',
+        hbs`
+        {{this.numberOfRenders}}
+    `
+      );
+
+      this.set('bookstore', bookstore);
+
+      assert.equal(books.length, 0, 'initial books.length');
+      await render(hbs`
+      {{x-foo bookstore=this.bookstore}}
+    `);
+
+      let text = this.element.textContent.trim();
+      assert.equal(text, '1', 'we rendered once initally');
+
+      this.store.pushPayload('com.example.Bookstore', {
+        data: {
+          id: 'urn:bookstore:1',
+          type: 'com.example.Bookstore',
+          attributes: {
+            '*books': ['urn:book:1', 'urn:book:2'],
+          },
+        },
+      });
+
+      await settled();
+      text = this.element.textContent.trim();
+      assert.equal(text, '2', 'we rerendered once the array changed');
+    });
+  });
+}

--- a/tests/unit/model/native-access-arrays-test.js
+++ b/tests/unit/model/native-access-arrays-test.js
@@ -99,17 +99,6 @@ if (CUSTOM_MODEL_CLASS) {
       assert.equal(slicedChapters[0].get('name'), 'The Boy Who Lived', `Array.slice still works`);
       assert.notEqual(slicedChapters, chapters, `Array.slice still works`);
 
-      let shiftedChapters = chapters.slice();
-      let shiftedChapter = shiftedChapters.shift();
-
-      assert.equal(shiftedChapters[0].get('name'), 'The Boy Who Lived', `Array.shift works`);
-      assert.equal(shiftedChapters.length, 1, `Array.shift works`);
-      assert.equal(shiftedChapter.get('name'), 'The Vanishing Glass', 'Array.shift works');
-
-      shiftedChapters.unshift(shiftedChapter);
-      assert.equal(shiftedChapters[0].get('name'), 'The Vanishing Glass', `Array.unshift works`);
-      assert.equal(shiftedChapters.length, 2, `Array.unshift works`);
-
       let toReverse = chapters.slice();
       toReverse.reverse();
       assert.equal(toReverse[0].get('name'), 'The Boy Who Lived', `Array.reverse works`);
@@ -177,6 +166,35 @@ if (CUSTOM_MODEL_CLASS) {
 
       chapters.fill({ name: 'Another name' });
       assert.equal(chapters[0].get('name'), 'Another name', 'Array.fill works');
+    });
+
+    test('managed arrays can be shifted and unshifted', function (assert) {
+      let model = this.store.push({
+        data: {
+          id: 'isbn:9780439708180',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            name: `Harry Potter and the Sorcerer's Stone`,
+            chapters: [
+              { name: 'Prologue' },
+              {
+                name: 'The Boy Who Lived',
+              },
+            ],
+          },
+        },
+      });
+
+      let chapters = model.get('chapters');
+
+      let shiftedChapter = chapters.shift();
+
+      assert.equal(chapters[0].get('name'), 'The Boy Who Lived', `Array.shift works`);
+      assert.equal(chapters.length, 1, `Array.shift works`);
+
+      chapters.unshift(shiftedChapter);
+      assert.equal(chapters[0].get('name'), 'Prologue', `Array.unshift works`);
+      assert.equal(chapters.length, 2, `Array.unshift works`);
     });
   });
 }


### PR DESCRIPTION
Because ManagedArray is now behind a proxy, it does not pass the internal ember `isEmberArray` check that uses a WeakSet https://github.com/emberjs/ember.js/blob/21bd70c773dcc4bfe4883d7943e8a68d203b5bad/packages/%40ember/-internals/utils/lib/ember-array.ts, so we have to access '[]' when we access ManagedArrays