### PR TITLE
Fix isDeleted rollbackAttributes for Custom Model Class

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -714,7 +714,11 @@ export default class M3RecordData {
     if (this._baseRecordData) {
       return this._baseRecordData.rollbackAttributes(...arguments);
     }
-    let dirtyKeys;
+    let dirtyKeys = [];
+    if (this.isDeleted()) {
+      this.setIsDeleted(false);
+      dirtyKeys.push('isDeleted');
+    }
     if (this.hasChangedAttributes()) {
       dirtyKeys = Object.keys(this._attributes);
       this._attributes = null;
@@ -737,7 +741,7 @@ export default class M3RecordData {
       }
     }
 
-    if (!(dirtyKeys && dirtyKeys.length > 0)) {
+    if (dirtyKeys.length === 0) {
       // nothing dirty on this record and we've already handled nested records
       return;
     }

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -138,7 +138,29 @@ for (let testRun = 0; testRun < 2; testRun++) {
         assert.equal(record.get('isLoaded'), true, 'record is loaded');
       });
       skip('isSaving', function () {});
-      skip('isDeleted', function () {});
+      test('isDeleted', function (assert) {
+        let data = {
+          data: {
+            id: 1,
+            type: 'com.example.bookstore.Book',
+            attributes: {
+              title: 'The Storm Before the Storm',
+              author: 'Mike Duncan',
+            },
+          },
+        };
+        let record = this.store.push(data);
+        assert.equal(record.get('isDeleted'), false, 'record starts off not deleted');
+        record.deleteRecord();
+        assert.equal(record.get('isDeleted'), true, 'record is now deleted');
+        record.rollbackAttributes();
+        assert.equal(
+          record.get('isDeleted'),
+          false,
+          'after rollbackAttributes record is no longer deleted'
+        );
+      });
+
       skip('isValid', function () {});
 
       test('isNew', function (assert) {


### PR DESCRIPTION
`isDeleted` state used to be handled by ember-data internal-model, with `3.28` we now need to handle it ourselves