### PR TITLE
Do not needlessly access `isDirty`

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -643,12 +643,21 @@ export default class MegamorphicModel extends EmberObject {
     schemaInterface._suppressNotifications = priorSuppressNotifications;
 
     const hasDirtyAttr = recordData.hasChangedAttributes();
-    const isDirty = get(this, 'isDirty');
+    if (!CUSTOM_MODEL_CLASS) {
+      const isDirty = get(this, 'isDirty');
 
-    if (hasDirtyAttr && !isDirty) {
-      this._updateCurrentState(!CUSTOM_MODEL_CLASS && updatedUncommitted);
-    } else if (!hasDirtyAttr && isDirty) {
-      this._updateCurrentState(!CUSTOM_MODEL_CLASS && loadedSaved);
+      if (hasDirtyAttr && !isDirty) {
+        this._updateCurrentState(updatedUncommitted);
+      } else if (!hasDirtyAttr && isDirty) {
+        this._updateCurrentState(loadedSaved);
+      }
+    } else {
+      const cachedIsDirty = this._topModel._isDirty;
+
+      // `isDirty` cached value does not match our current one -> we need to update our state
+      if (hasDirtyAttr !== cachedIsDirty) {
+        this._updateCurrentState();
+      }
     }
   }
 
@@ -714,6 +723,7 @@ MegamorphicModel.prototype.currentState = null;
 MegamorphicModel.prototype.isError = null;
 MegamorphicModel.prototype.adapterError = null;
 MegamorphicModel.prototype._identifier = null;
+MegamorphicModel.prototype._isDirty = null;
 
 MegamorphicModel.relationshipsByName = new Map();
 
@@ -756,11 +766,14 @@ if (CUSTOM_MODEL_CLASS) {
     if (this !== this._topModel) {
       return this._topModel.get('isDirty');
     }
-    return (
+
+    // We cache the `_isDirty` value so that we can use it in deciding whether to notify a property change
+    // without having to consume `isDirty` to avoid rerender loops and get a perf boost
+    this._isDirty =
       this._recordData.hasChangedAttributes() ||
       ((this._recordData.isNew() || this._recordData.isDeleted()) &&
-        this._recordData.isNew() !== this._recordData.isDeleted())
-    );
+        this._recordData.isNew() !== this._recordData.isDeleted());
+    return this._isDirty;
   });
 } else {
   isDirty = retrieveFromCurrentState;
@@ -864,15 +877,17 @@ export class EmbeddedMegamorphicModel extends MegamorphicModel {
   }
 
   _updateCurrentState(state) {
-    if (state === loadedSaved) {
-      let topRecordData = recordDataFor(this._topModel);
-      if (topRecordData.hasChangedAttributes()) {
-        // Nested models maintain state with their parents; this makes sense
-        // until we let people save nested models independently.  However, it
-        // means that nested models should not reset their parents to "not
-        // dirty" when their last changed attribute is set to its original
-        // value, if their parent has some other dirty attribute
-        return;
+    if (!CUSTOM_MODEL_CLASS) {
+      if (state === loadedSaved) {
+        let topRecordData = recordDataFor(this._topModel);
+        if (topRecordData.hasChangedAttributes()) {
+          // Nested models maintain state with their parents; this makes sense
+          // until we let people save nested models independently.  However, it
+          // means that nested models should not reset their parents to "not
+          // dirty" when their last changed attribute is set to its original
+          // value, if their parent has some other dirty attribute
+          return;
+        }
       }
     }
     return super._updateCurrentState(state);

--- a/addon/model.js
+++ b/addon/model.js
@@ -643,20 +643,20 @@ export default class MegamorphicModel extends EmberObject {
     schemaInterface._suppressNotifications = priorSuppressNotifications;
 
     const hasDirtyAttr = recordData.hasChangedAttributes();
-    if (!CUSTOM_MODEL_CLASS) {
+    if (CUSTOM_MODEL_CLASS) {
+      const cachedIsDirty = this._topModel._isDirty;
+
+      // `isDirty` cached value does not match our current one -> we need to update our state
+      if (hasDirtyAttr !== cachedIsDirty) {
+        this._updateCurrentState();
+      }
+    } else {
       const isDirty = get(this, 'isDirty');
 
       if (hasDirtyAttr && !isDirty) {
         this._updateCurrentState(updatedUncommitted);
       } else if (!hasDirtyAttr && isDirty) {
         this._updateCurrentState(loadedSaved);
-      }
-    } else {
-      const cachedIsDirty = this._topModel._isDirty;
-
-      // `isDirty` cached value does not match our current one -> we need to update our state
-      if (hasDirtyAttr !== cachedIsDirty) {
-        this._updateCurrentState();
       }
     }
   }

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -8,6 +8,7 @@ import { render } from '@ember/test-helpers';
 import { gte } from 'ember-compatibility-helpers';
 import propGet from '../../helpers/prop-get';
 import DefaultSchema from 'ember-m3/services/m3-schema';
+import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 
 let computeNestedModel = function computeNestedModel(key, value) {
   if (value && typeof value === 'object' && !isArray(value)) {
@@ -330,5 +331,34 @@ if (gte('3.24.0')) {
 
       assert.equal(this.element.innerText, 'Book is dirty', 'Book renders as dirty');
     });
+
+    if (CUSTOM_MODEL_CLASS) {
+      test('creating a record does not cause rerenders from reading `isDirty` when key values are undefined', async function (assert) {
+        this.owner.register(
+          'component:show-dirtyness',
+          class ShowDirtyness extends Component {
+            layout = hbs`
+          {{#if this.myBook.isDirty}}
+            Book is dirty
+          {{/if}}
+      `;
+
+            get myBook() {
+              // Passing `{ someKey: undefined }` will trigger a property change on the newly created model, but will not dirty the properties
+              // If we are not careful we could create a rerender cycle by notifying `isDiry` change on a record in the middle of instantiation
+              return this.store.createRecord('com.example.bookstore.book', { someKey: undefined });
+            }
+          }
+        );
+
+        this.set('store', this.store);
+
+        await render(hbs`
+        {{show-dirtyness store=this.store}}
+      `);
+
+        assert.equal(this.element.innerText, 'Book is dirty', 'Book renders as dirty');
+      });
+    }
   });
 }

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -345,7 +345,7 @@ if (gte('3.24.0')) {
 
             get myBook() {
               // Passing `{ someKey: undefined }` will trigger a property change on the newly created model, but will not dirty the properties
-              // If we are not careful we could create a rerender cycle by notifying `isDiry` change on a record in the middle of instantiation
+              // If we are not careful we could create a rerender cycle by notifying `isDirty` change on a record in the middle of instantiation
               return this.store.createRecord('com.example.bookstore.book', { someKey: undefined });
             }
           }


### PR DESCRIPTION
We were entangling `isDirty` by doing a `get(this, 'isDirty');` even when no one had read our dirty state. In some edge cases, this could result in rerendering errors, and was also not great for performance. 