### PR TITLE
Switch m3 array proxies to proxy [] insted of BaseRecordArray

### DIFF
--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -197,7 +197,7 @@ if (CUSTOM_MODEL_CLASS) {
       });
     }
 
-    // Need to subclass `removeAt`, `pushObject`, and `insertAt` because the default implementations by
+    // Need to override `removeAt`, `pushObject`, and `insertAt` because the default implementations by
     // MutableArray will end up calling replaceInNativeArray and not our own replace after an `isArray` check
     // https://github.com/emberjs/ember.js/blob/21bd70c773dcc4bfe4883d7943e8a68d203b5bad/packages/%40ember/-internals/metal/lib/array.ts#L27
     // https://github.com/emberjs/ember.js/blob/21bd70c773dcc4bfe4883d7943e8a68d203b5bad/packages/%40ember/-internals/metal/lib/array.ts#L38

--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -39,16 +39,16 @@ if (CUSTOM_MODEL_CLASS) {
 
   const BaseRecordArrayProxyHandler = class {
     getPrototypeOf(target) {
-      return Object.getPrototypeOf(target._instance);
+      return Object.getPrototypeOf(target.__recordArray);
     }
     get(target, key, receiver) {
       let index = convertToInt(key);
 
       if (index !== null) {
-        return target._instance.objectAt(key);
+        return target.__recordArray.objectAt(key);
       }
 
-      return Reflect.get(target._instance, key, receiver);
+      return Reflect.get(target.__recordArray, key, receiver);
     }
 
     set(target, key, value, receiver) {
@@ -57,7 +57,7 @@ if (CUSTOM_MODEL_CLASS) {
       if (index !== null) {
         receiver.replace(index, 1, [value]);
       } else {
-        Reflect.set(target._instance, key, value);
+        Reflect.set(target.__recordArray, key, value);
       }
 
       return true;
@@ -81,7 +81,7 @@ if (CUSTOM_MODEL_CLASS) {
       let instance = super.create(...args);
 
       let arr = [];
-      arr._instance = instance;
+      arr.__recordArray = instance;
       return new Proxy(arr, baseRecordArrayProxyHandler);
     }
 

--- a/addon/model.js
+++ b/addon/model.js
@@ -21,7 +21,6 @@ import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 import { RootState, Errors as StoreErrors } from '@ember-data/store/-private';
 import { Errors as ModelErrors } from '@ember-data/model/-private';
 import { REFERENCE, schemaTypesInfo } from './utils/schema-types-info';
-import { MANAGED_ARRAYS } from './base-record-array';
 
 // Errors moved from @ember-data/store to @ember-data/model as of 3.15.0
 const Errors = ModelErrors || StoreErrors;
@@ -529,12 +528,6 @@ export default class MegamorphicModel extends EmberObject {
           this
         );
       }
-    }
-    // If a value returned from unknownProperty is a ManagedArray we need to access '[]'
-    // to keep parity with how ember treats arrays
-    // see https://github.com/emberjs/ember.js/blob/3ce13cea235cde8a87d89473533c453523412764/packages/%40ember/-internals/metal/lib/property_get.ts#L136
-    if (MANAGED_ARRAYS.has(returnValue)) {
-      get(returnValue, '[]');
     }
     return returnValue;
   }

--- a/addon/services/m3-schema.js
+++ b/addon/services/m3-schema.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { isArray } from '@ember/array';
 import { isResolvedValue as _isResolvedValue } from '../utils/resolve';
+import isM3Array from '../utils/is-m3-array';
 
 export default class DefaultSchema extends Service {
   computeAttribute(/* key, value, modelName, schemaInterface */) {}
@@ -98,7 +99,7 @@ export default class DefaultSchema extends Service {
         //
         // empty native arrays are treated as unresolved as this is the primary
         // way of setting arrays of new nested models
-        return !Array.isArray(value);
+        return !Array.isArray(value) || isM3Array(value);
       }
     }
   }

--- a/addon/utils/is-m3-array.js
+++ b/addon/utils/is-m3-array.js
@@ -1,0 +1,4 @@
+import BaseRecordArray from '../base-record-array';
+export default function isM3Array(obj) {
+  return obj instanceof BaseRecordArray;
+}

--- a/tests/integration/managed-array-tracked-test.js
+++ b/tests/integration/managed-array-tracked-test.js
@@ -33,6 +33,10 @@ if (CUSTOM_MODEL_CLASS) {
                   })
                 )
               );
+            } else if (Array.isArray(value)) {
+              return schemaInterface.managedArray(
+                value.map((val) => schemaInterface.nested({ attributes: val }))
+              );
             } else if (typeof value === 'object') {
               return schemaInterface.nested({ attributes: value });
             }
@@ -132,6 +136,37 @@ if (CUSTOM_MODEL_CLASS) {
         'George R. R. Martin',
         'Recomputed the first book after addition'
       );
+    });
+
+    // We have run into scenarios like these with users stashing M3 Arrays on POJOs in services, and then accessing them and
+    // modifying during a render
+    test('Can modify a managed array after creation without triggering rerendering assertions', async function (assert) {
+      let bookstore = this.store.createRecord('com.example.Bookstore', {
+        books: [{ name: 'Igor' }, { name: 'David' }],
+      });
+
+      let books = bookstore.books;
+
+      this.owner.register(
+        'component:first-book',
+        class FirstBookComponent extends Component {
+          get firstBook() {
+            books.shift();
+            return books[0];
+          }
+        }
+      );
+      this.owner.register(
+        'template:components/first-book',
+        hbs`<h1>{{this.firstBook.name}}</h1>
+      `
+      );
+
+      await render(hbs`
+    {{first-book}}
+  `);
+      let text = this.element.textContent.trim();
+      assert.equal(text, 'David', 'Rendered the component');
     });
 
     test('mutating arrays causes length tracked properties to recompute', async function (assert) {

--- a/tests/unit/record-array-test.js
+++ b/tests/unit/record-array-test.js
@@ -7,6 +7,8 @@ import { flushChanges } from 'ember-m3/utils/notify-changes';
 import { isArray } from '@ember/array';
 import MutableArray from '@ember/array/mutable';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
+import isM3Array from 'ember-m3/utils/is-m3-array';
+import EmberObject from '@ember/object';
 
 module('unit/record-array', function (hooks) {
   setupTest(hooks);
@@ -103,6 +105,7 @@ module('unit/record-array', function (hooks) {
       { id: 'isbn:2', type: 'com.example.bookstore.Book' },
     ]);
     assert.equal(recordArray._resolved, false, 'unresolved after setting references');
+
     assert.equal(recordArray.get('firstObject.title'), 'pretty good book', 'reference resolved');
     assert.equal(recordArray._resolved, true, 'lazily resolved');
 
@@ -282,6 +285,21 @@ module('unit/record-array', function (hooks) {
         assert.equal(recordArray._resolved, false, '_removeObjects does not resolve');
         assert.deepEqual(recordArray.toArray().mapBy('id'), ['isbn:1'], 'records removed');
       });
+    });
+
+    test('isM3Array detects m3 managed arrays', function (assert) {
+      let recordArray = this.createRecordArray();
+      assert.equal(isM3Array(recordArray), true, 'recordArray detected');
+
+      assert.equal(isM3Array([]), false, 'plain js arrays return false');
+      assert.equal(isM3Array(null), false, 'other objects also return false');
+      assert.equal(isM3Array(undefined), false, 'other objects also return false');
+      assert.equal(isM3Array('hi'), false, 'other objects also return false');
+      assert.equal(isM3Array({}), false, 'other objects also return false');
+      class EmberArray extends EmberObject.extend(MutableArray) {}
+
+      assert.equal(isM3Array(EmberArray.create()), false, 'other ember arrays return false');
+      assert.equal(isM3Array(EmberObject.create()), false, 'other ember objects return false');
     });
   }
 });


### PR DESCRIPTION
The previous approach would result in apps breaking due to subtle differences in how ember entangles `[]` on template access vs us doing it in `objectAt`, `length` and `unknownProperty`.

This will be a breaking change for apps relying on `Array.isArray` returning false for m3 arrays. Using `addon/utils/is-m3-array.js` should enable those apps to migrate