### PR TITLE
Do not emit array change events when app is being destroyed

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -587,6 +587,10 @@ export default class M3RecordData {
 
   removeFromRecordArrays() {
     if (CUSTOM_MODEL_CLASS) {
+      // No need to remove us from record arrays if the store is beeing destroyed
+      if (this.globalM3CacheRD._storeIsDestroying) {
+        return;
+      }
       this._recordArrays.forEach((recordArray) => {
         recordArray._removeRecordData(this);
       });

--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -587,8 +587,8 @@ export default class M3RecordData {
 
   removeFromRecordArrays() {
     if (CUSTOM_MODEL_CLASS) {
-      // No need to remove us from record arrays if the store is beeing destroyed
-      if (this.globalM3CacheRD._storeIsDestroying) {
+      // No need to remove us from record arrays if the app is being torn down
+      if (this._schema.isDestroying) {
         return;
       }
       this._recordArrays.forEach((recordArray) => {

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -178,6 +178,14 @@ export default class M3Store extends Store {
     return super.teardownRecord(record);
   }
 
+  willDestroy() {
+    if (CUSTOM_MODEL_CLASS) {
+      this._globalM3RecordDataCache._storeIsDestroying = true;
+    }
+
+    return super.willDestroy(...arguments);
+  }
+
   /**
    * A thin wrapper around the API response that knows how to look up references
    *

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -178,14 +178,6 @@ export default class M3Store extends Store {
     return super.teardownRecord(record);
   }
 
-  willDestroy() {
-    if (CUSTOM_MODEL_CLASS) {
-      this._globalM3RecordDataCache._storeIsDestroying = true;
-    }
-
-    return super.willDestroy(...arguments);
-  }
-
   /**
    * A thin wrapper around the API response that knows how to look up references
    *

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -2541,7 +2541,7 @@ for (let testRun = 0; testRun < 2; testRun++) {
           'initial state as expected'
         );
 
-        run(() => this.store.destroy());
+        run(() => this.owner.destroy());
         assert.equal(didChangeCount, 0, 'Did not emit change events');
       });
     }

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -2497,6 +2497,55 @@ for (let testRun = 0; testRun < 2; testRun++) {
       );
     });
 
+    if (CUSTOM_MODEL_CLASS) {
+      test('.unloadRecord doese not update reference record arrays when the store is being destroyed', function (assert) {
+        let model = run(() => {
+          return this.store.push({
+            data: {
+              id: 'isbn:9780439708180',
+              type: 'com.example.bookstore.Book',
+              attributes: {
+                name: `Harry Potter and the Sorcerer's Stone`,
+                '*relatedBooks': ['isbn:9780439064873', 'isbn:9780439136365'],
+              },
+            },
+            included: [
+              {
+                id: 'isbn:9780439064873',
+                type: 'com.example.bookstore.Book',
+                attributes: {
+                  name: `Harry Potter and the Chamber of Secrets`,
+                },
+              },
+              {
+                id: 'isbn:9780439136365',
+                type: 'com.example.bookstore.Book',
+                attributes: {
+                  name: `Harry Potter and the Prisoner of Azkaban`,
+                },
+              },
+            ],
+          });
+        });
+
+        let books = model.get('relatedBooks');
+        let didChangeCount = 0;
+        books.addArrayObserver({
+          arrayDidChange() {
+            ++didChangeCount;
+          },
+        });
+        assert.deepEqual(
+          model.get('relatedBooks').mapBy('name'),
+          [`Harry Potter and the Chamber of Secrets`, `Harry Potter and the Prisoner of Azkaban`],
+          'initial state as expected'
+        );
+
+        run(() => this.store.destroy());
+        assert.equal(didChangeCount, 0, 'Did not emit change events');
+      });
+    }
+
     test('.unloadRecord on a nested model warns and does not error', function (assert) {
       let model = run(() => {
         return this.store.push({


### PR DESCRIPTION
Speeds up test runs, and also makes app tests more robust against bad teardown states.