### PR TITLE
Sync projections and base model deleted state with CUSTOM_MODEL_CLASS

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -483,10 +483,16 @@ export default class M3RecordData {
   }
 
   setIsDeleted(value) {
+    if (this._baseRecordData) {
+      return this._baseRecordData.setIsDeleted(value);
+    }
     this._isDeleted = value;
   }
 
   isDeleted() {
+    if (this._baseRecordData) {
+      return this._baseRecordData.isDeleted();
+    }
     return this._isDeleted;
   }
 


### PR DESCRIPTION
Projections and base models now have a synced up deleted state.