### PR TITLE
Do not use an EmberArray for m3 array internal state

### DIFF
--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -89,7 +89,7 @@ if (CUSTOM_MODEL_CLASS) {
       super.init(...arguments);
       this._references = [];
       if (!this._objects) {
-        this._objects = A();
+        this._objects = [];
       }
       this._resolved = false;
       this.store = this.store || null;
@@ -106,7 +106,7 @@ if (CUSTOM_MODEL_CLASS) {
         }
       }
 
-      this._objects.replace(idx, removeAmt, newObjects);
+      this._objects.splice(idx, removeAmt, ...newObjects);
       this.arrayContentDidChange(idx, removeAmt, newObjects.length);
       this._registerWithObjects(newObjects);
       this._resolved = true;
@@ -121,13 +121,16 @@ if (CUSTOM_MODEL_CLASS) {
 
     _removeObject(object) {
       if (this._resolved) {
-        this._objects.removeObject(object);
-        deferArrayPropertyChange(this.store, this, 0, 1, 0);
-        deferPropertyChange(this.store, this, '[]');
-        deferPropertyChange(this.store, this, 'length');
-        // eager change events here; we're not processing payloads (that goes
-        // through `_setInternalModels`); we're doing `unloadRecord`
-        flushChanges(this.store);
+        let idx = this._objects.indexOf(object);
+        if (idx > -1) {
+          this._objects.splice(idx, 1);
+          deferArrayPropertyChange(this.store, this, idx, 1, 0);
+          deferPropertyChange(this.store, this, '[]');
+          deferPropertyChange(this.store, this, 'length');
+          // eager change events here; we're not processing payloads (that goes
+          // through `_setInternalModels`); we're doing `unloadRecord`
+          flushChanges(this.store);
+        }
       } else {
         for (let j = 0; j < this._references.length; ++j) {
           let { id, type } = this._references[j];
@@ -146,7 +149,7 @@ if (CUSTOM_MODEL_CLASS) {
     _setObjects(objects, triggerChange = true) {
       let originalLength = this._objects.length;
       if (triggerChange) {
-        this._objects.replace(0, this._objects.length, objects);
+        this._objects.splice(0, this._objects.length, ...objects);
         deferArrayPropertyChange(this.store, this, 0, originalLength, this._objects.length);
         deferPropertyChange(this.store, this, '[]');
         deferPropertyChange(this.store, this, 'length');
@@ -168,7 +171,7 @@ if (CUSTOM_MODEL_CLASS) {
       this._references = references;
       this._resolved = false;
       let originalLength = this._objects.length;
-      this._objects = A();
+      this._objects = [];
       deferArrayPropertyChange(this.store, this, 0, originalLength, this._objects.length);
       deferPropertyChange(this.store, this, '[]');
       deferPropertyChange(this.store, this, 'length');
@@ -182,7 +185,7 @@ if (CUSTOM_MODEL_CLASS) {
         }
         let index = this._objects.indexOf(record);
         if (index > -1) {
-          this._objects.removeObject(record);
+          this._objects.splice(index, 1);
           this.arrayContentDidChange(index, 1, 0);
         }
       }

--- a/addon/managed-array.js
+++ b/addon/managed-array.js
@@ -7,6 +7,7 @@ import { deprecate } from '@ember/debug';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 import MegamorphicModel, { EmbeddedMegamorphicModel } from './model';
 import { recordIdentifierFor } from '@ember-data/store';
+import { A } from '@ember/array';
 
 /**
  * M3TrackedArray
@@ -31,7 +32,7 @@ if (CUSTOM_MODEL_CLASS) {
         id: 'm3.tracked-array.value',
         until: '4.0',
       });
-      return this._objects;
+      return A(this._objects);
     }
 
     get value() {


### PR DESCRIPTION
We don't need to have `_objects` be tracked because we manage notifications ourselves. Having `_objects` be an `Ember.A()` just ends up triggering change notifications that don't go anywhere.