### PR TITLE
Add IE testing and guard proxies when they are not present

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,3 +106,21 @@ jobs:
         run: yarn --frozen-lockfile --install
       - name: try ${{matrix.try-scenario}}
         run: yarn run ember try:one ${{matrix.try-scenario}}
+
+  browser-tests:
+    needs: [lint]
+    runs-on: windows-latest
+
+    name: test-ie
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14.x' # preferred node version
+      - name: yarn install
+        run: yarn --frozen-lockfile --install
+      - name: lint
+        env:
+          TESTEM_CI_LAUNCHER: IE
+          CI: true
+        run: yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,8 +119,8 @@ jobs:
           node-version: '14.x' # preferred node version
       - name: yarn install
         run: yarn --frozen-lockfile --install
-      - name: lint
+      - name: test
         env:
           TESTEM_CI_LAUNCHER: IE
           CI: true
-        run: yarn lint
+        run: yarn test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,6 @@ jobs:
   browser-tests:
     needs: [lint]
     runs-on: windows-latest
-
     name: test-ie
     steps:
       - uses: actions/checkout@v2

--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -17,8 +17,7 @@ import {
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 import { recordDataToRecordMap, recordToRecordArrayMap } from './utils/caches';
 import { recordIdentifierFor } from '@ember-data/store';
-
-const HAS_NATIVE_PROXY = typeof Proxy === 'function';
+import HAS_NATIVE_PROXY from './utils/has-native-proxy';
 
 /**
  * BaseRecordArray

--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -18,6 +18,8 @@ import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 import { recordDataToRecordMap, recordToRecordArrayMap } from './utils/caches';
 import { recordIdentifierFor } from '@ember-data/store';
 
+const HAS_NATIVE_PROXY = typeof Proxy === 'function';
+
 /**
  * BaseRecordArray
  *
@@ -79,10 +81,14 @@ if (CUSTOM_MODEL_CLASS) {
     // public RecordArray API
     static create(...args) {
       let instance = super.create(...args);
-
-      let arr = [];
-      arr.__recordArray = instance;
-      return new Proxy(arr, baseRecordArrayProxyHandler);
+      if (HAS_NATIVE_PROXY) {
+        let arr = [];
+        arr.__recordArray = instance;
+        return new Proxy(arr, baseRecordArrayProxyHandler);
+        // IE11 support
+      } else {
+        return instance;
+      }
     }
 
     init() {

--- a/addon/utils/has-native-proxy.js
+++ b/addon/utils/has-native-proxy.js
@@ -1,0 +1,2 @@
+const HAS_NATIVE_PROXY = typeof Proxy === 'function';
+export default HAS_NATIVE_PROXY;

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "ember-compatibility-helpers": "^1.2.5",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.1",
+    "ember-fetch": "^8.1.1",
     "ember-inflector": "^4.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-lodash": "^4.17.5",

--- a/testem.js
+++ b/testem.js
@@ -2,7 +2,7 @@
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
-  launch_in_ci: ['Chrome'],
+  launch_in_ci: [process.env.TESTEM_CI_LAUNCHER || 'Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
   browser_args: {

--- a/tests/dummy/app/adapters/-json-api.js
+++ b/tests/dummy/app/adapters/-json-api.js
@@ -1,4 +1,5 @@
 import EmberObject from '@ember/object';
+import fetch from 'fetch';
 
 export default class Adapter extends EmberObject {
   async ajax(url) {

--- a/tests/helpers/prop-get.js
+++ b/tests/helpers/prop-get.js
@@ -1,9 +1,10 @@
 import { gte } from 'ember-compatibility-helpers';
+import HAS_NATIVE_PROXY from 'ember-m3/utils/has-native-proxy';
 
 // If ember-data version is before 3.28 we want to do record.get('property')
 // otherwise we want to use native property access in newer versions
 export default function propGet(record, key) {
-  if (gte('@ember-data/model', '3.28.0') || gte('ember-data', '3.28.0')) {
+  if ((gte('@ember-data/model', '3.28.0') || gte('ember-data', '3.28.0')) && HAS_NATIVE_PROXY) {
     return record[key];
   } else {
     return record.get(key);

--- a/tests/helpers/schema-versions.js
+++ b/tests/helpers/schema-versions.js
@@ -15,21 +15,17 @@ function computeAttributeCompat(v2Schema, key, value, modelName, schemaInterface
     }
     return array;
   };
-  let compatSchemaInterface = new Proxy(schemaInterface, {
-    get(object, property) {
-      switch (property) {
-        case 'nested':
-          return isReference ? identity : addTarget;
-        case 'reference':
-          return isReference ? addTarget : identity;
-        case 'managedArray':
-          return managedArray;
-        default:
-          return object[property];
-      }
+  let compatSchemaInterface = {
+    get nested() {
+      return isReference ? identity : addTarget;
     },
-  });
-
+    get reference() {
+      return isReference ? addTarget : identity;
+    },
+    get managedArray() {
+      return managedArray;
+    },
+  };
   let result = v2Schema.computeAttribute(key, value, modelName, compatSchemaInterface);
   if (result === arrayTarget) {
     return arrayTarget;

--- a/tests/integration/managed-array-tracked-test.js
+++ b/tests/integration/managed-array-tracked-test.js
@@ -216,7 +216,7 @@ if (CUSTOM_MODEL_CLASS) {
         'component:x-foo',
         class XFooComponent extends Component {
           get hasAnything() {
-            return this.bookstore.books.length > 0;
+            return propGet(propGet(this.bookstore, 'books'), 'length') > 0;
           }
         }
       );
@@ -233,7 +233,7 @@ if (CUSTOM_MODEL_CLASS) {
 
       this.set('bookstore', bookstore);
 
-      assert.equal(books.length, 0, 'initial books.length');
+      assert.equal(propGet(books, 'length'), 0, 'initial books.length');
       await render(hbs`
       {{x-foo bookstore=this.bookstore}}
     `);
@@ -252,7 +252,7 @@ if (CUSTOM_MODEL_CLASS) {
       });
 
       await settled();
-      assert.equal(books.length, 2, 'updated books.length');
+      assert.equal(propGet(books, 'length'), 2, 'updated books.length');
       text = this.element.textContent.trim();
       assert.equal(text, 'Has Content', 'length updated');
     });
@@ -301,7 +301,7 @@ if (CUSTOM_MODEL_CLASS) {
         'component:x-foo',
         class XFooComponent extends Component {
           get numberOfRenders() {
-            this.bookstore.books;
+            propGet(this.bookstore, 'books');
             count++;
             return count;
           }
@@ -316,7 +316,7 @@ if (CUSTOM_MODEL_CLASS) {
 
       this.set('bookstore', bookstore);
 
-      assert.equal(books.length, 0, 'initial books.length');
+      assert.equal(propGet(books, 'length'), 0, 'initial books.length');
       await render(hbs`
       {{x-foo bookstore=this.bookstore}}
     `);

--- a/tests/integration/managed-array-tracked-test.js
+++ b/tests/integration/managed-array-tracked-test.js
@@ -6,6 +6,7 @@ import DefaultSchema from 'ember-m3/services/m3-schema';
 import Component from '@ember/component';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 import HAS_NATIVE_PROXY from 'ember-m3/utils/has-native-proxy';
+import propGet from '../helpers/prop-get';
 
 if (CUSTOM_MODEL_CLASS) {
   module('integration/managed-array-tracked', function (hooks) {
@@ -13,9 +14,6 @@ if (CUSTOM_MODEL_CLASS) {
 
     hooks.beforeEach(function () {
       class TestSchema extends DefaultSchema {
-        useNativeProperties() {
-          return true;
-        }
         computeAttribute(key, value, modelName, schemaInterface) {
           let refValue = schemaInterface.getAttr(`*${key}`);
           if (typeof refValue === 'string') {
@@ -98,7 +96,7 @@ if (CUSTOM_MODEL_CLASS) {
         'component:first-book',
         class FirstBookComponent extends Component {
           get firstBook() {
-            return this.bookstore.books[0];
+            return propGet(this.bookstore, 'books').objectAt(0);
           }
         }
       );
@@ -109,7 +107,7 @@ if (CUSTOM_MODEL_CLASS) {
       );
 
       let bookstore = this.store.peekRecord('com.example.Bookstore', 'urn:bookstore:1');
-      let books = bookstore.books;
+      let books = propGet(bookstore, 'books');
 
       this.set('bookstore', bookstore);
       await render(hbs`

--- a/tests/integration/managed-array-tracked-test.js
+++ b/tests/integration/managed-array-tracked-test.js
@@ -12,43 +12,46 @@ if (CUSTOM_MODEL_CLASS) {
     setupRenderingTest(hooks);
 
     hooks.beforeEach(function () {
-      this.owner.register(
-        'service:m3-schema',
-        class TestSchema extends DefaultSchema {
-          useNativeProperties() {
-            return true;
-          }
-          computeAttribute(key, value, modelName, schemaInterface) {
-            let refValue = schemaInterface.getAttr(`*${key}`);
-            if (typeof refValue === 'string') {
-              return schemaInterface.reference({
-                type: null,
-                id: refValue,
-              });
-            } else if (Array.isArray(refValue)) {
-              return schemaInterface.managedArray(
-                refValue.map((id) =>
-                  schemaInterface.reference({
-                    type: null,
-                    id,
-                  })
-                )
-              );
-            } else if (Array.isArray(value)) {
-              return schemaInterface.managedArray(
-                value.map((val) => schemaInterface.nested({ attributes: val }))
-              );
-            } else if (typeof value === 'object') {
-              return schemaInterface.nested({ attributes: value });
-            }
-
-            return value;
-          }
-          includesModel(modelName) {
-            return /^com\.example\./.test(modelName);
-          }
+      class TestSchema extends DefaultSchema {
+        useNativeProperties() {
+          return true;
         }
-      );
+        computeAttribute(key, value, modelName, schemaInterface) {
+          let refValue = schemaInterface.getAttr(`*${key}`);
+          if (typeof refValue === 'string') {
+            return schemaInterface.reference({
+              type: null,
+              id: refValue,
+            });
+          } else if (Array.isArray(refValue)) {
+            return schemaInterface.managedArray(
+              refValue.map((id) =>
+                schemaInterface.reference({
+                  type: null,
+                  id,
+                })
+              )
+            );
+          } else if (Array.isArray(value)) {
+            return schemaInterface.managedArray(
+              value.map((val) => schemaInterface.nested({ attributes: val }))
+            );
+          } else if (typeof value === 'object') {
+            return schemaInterface.nested({ attributes: value });
+          }
+
+          return value;
+        }
+        includesModel(modelName) {
+          return /^com\.example\./.test(modelName);
+        }
+      }
+      if (HAS_NATIVE_PROXY) {
+        TestSchema.prototype.useNativeProperties = function () {
+          return true;
+        };
+      }
+      this.owner.register('service:m3-schema', TestSchema);
       this.store = this.owner.lookup('service:store');
     });
 

--- a/tests/integration/managed-array-tracked-test.js
+++ b/tests/integration/managed-array-tracked-test.js
@@ -5,7 +5,7 @@ import hbs from 'htmlbars-inline-precompile';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import Component from '@ember/component';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
-import HAS_NATIVE_PROXY from '../../addon/utils/has-native-proxy';
+import HAS_NATIVE_PROXY from 'ember-m3/utils/has-native-proxy';
 
 if (CUSTOM_MODEL_CLASS) {
   module('integration/managed-array-tracked', function (hooks) {

--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -531,7 +531,7 @@ for (let testRun = 0; testRun < 2; testRun++) {
             type: 'com.example.bookstore.Book',
             attributes: {
               name: `Harry Potter and the Sorcerer's Stone`,
-              pubDate: 'September 1989',
+              pubDate: '01 September 1989',
               chapters: {
                 one: {
                   title: 'The Boy Who Lived',
@@ -542,7 +542,7 @@ for (let testRun = 0; testRun < 2; testRun++) {
         })
       );
 
-      let sept1989 = new Date(Date.parse('September 1989')).getTime();
+      let sept1989 = new Date(Date.parse('01 September 1989')).getTime();
 
       assert.equal(
         get(model, 'title'),

--- a/tests/unit/model/native-access-arrays-test.js
+++ b/tests/unit/model/native-access-arrays-test.js
@@ -5,6 +5,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
+import HAS_NATIVE_PROXY from 'ember-m3/utils/has-native-proxy';
 
 function computeNestedModel(key, value /*, modelName, schemaInterface */) {
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
@@ -37,7 +38,7 @@ class TestSchema extends DefaultSchema {
   }
 }
 
-if (CUSTOM_MODEL_CLASS) {
+if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
   module(`unit/model/native-access-arrays`, function (hooks) {
     setupTest(hooks);
 

--- a/tests/unit/model/native-access-test.js
+++ b/tests/unit/model/native-access-test.js
@@ -2,8 +2,9 @@ import { test, module } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
+import HAS_NATIVE_PROXY from 'ember-m3/utils/has-native-proxy';
 
-if (CUSTOM_MODEL_CLASS) {
+if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
   class TestSchema extends DefaultSchema {
     includesModel(modelName) {
       return /^com.example.bookstore\./i.test(modelName);

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -332,10 +332,10 @@ if (gte('3.24.0')) {
         {{show-dirtyness book=this.book}}
       `);
 
-      assert.equal(this.element.innerText, 'Book is dirty', 'Book renders as dirty');
+      assert.equal(this.element.innerText.trim(), 'Book is dirty', 'Book renders as dirty');
     });
 
-    if (CUSTOM_MODEL_CLASS) {
+    if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
       test('creating a record does not cause rerenders from reading `isDirty` when key values are undefined', async function (assert) {
         this.owner.register(
           'component:show-dirtyness',

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -78,10 +78,6 @@ class TestSchema extends DefaultSchema {
 }
 
 class TestSchemaOldHooks extends DefaultSchema {
-  useNativeProperties() {
-    return gte('@ember-data/model', '3.28.0') || gte('ember-data', '3.28.0');
-  }
-
   includesModel() {
     return true;
   }

--- a/tests/unit/model/state-test.js
+++ b/tests/unit/model/state-test.js
@@ -9,6 +9,7 @@ import { gte } from 'ember-compatibility-helpers';
 import propGet from '../../helpers/prop-get';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
+import HAS_NATIVE_PROXY from 'ember-m3/utils/has-native-proxy';
 
 let computeNestedModel = function computeNestedModel(key, value) {
   if (value && typeof value === 'object' && !isArray(value)) {
@@ -42,9 +43,6 @@ let computeAttributeReference = function computeAttributeReference(
 };
 
 class TestSchema extends DefaultSchema {
-  useNativeProperties() {
-    return gte('@ember-data/model', '3.28.0') || gte('ember-data', '3.28.0');
-  }
   includesModel() {
     return true;
   }
@@ -94,6 +92,15 @@ class TestSchemaOldHooks extends DefaultSchema {
   computeNestedModel(key, value, modelName, schemaInterface) {
     return computeNestedModel(key, value, modelName, schemaInterface);
   }
+}
+
+if ((gte('@ember-data/model', '3.28.0') || gte('ember-data', '3.28.0')) && HAS_NATIVE_PROXY) {
+  TestSchemaOldHooks.prototype.useNativeProperties = function () {
+    return true;
+  };
+  TestSchema.prototype.useNativeProperties = function () {
+    return true;
+  };
 }
 
 for (let testRun = 0; testRun < 2; testRun++) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,6 +1770,13 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
+"@types/acorn@^4.0.3":
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/@types/acorn/-/acorn-4.0.6.tgz#d61ca5480300ac41a7d973dd5b84d0a591154a22"
+  integrity sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==
+  dependencies:
+    "@types/estree" "*"
+
 "@types/body-parser@*":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
@@ -1916,6 +1923,11 @@
   version "15.12.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
   integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
+
+"@types/node@^9.6.0":
+  version "9.6.61"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.61.tgz#29f124eddd41c4c74281bd0b455d689109fc2a2d"
+  integrity sha512-/aKAdg5c8n468cYLy2eQrcR5k6chlbNwZNGUj3TboyPa2hcO2QAJcfymlqPzMiRj8B6nYKXjzQz36minFE0RwQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -2160,6 +2172,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abortcontroller-polyfill@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.3.tgz#1b5b487bd6436b5b764fd52a612509702c3144b5"
+  integrity sha512-zetDJxd89y3X99Kvo4qFx8GKlt6GsvN3UcRZHwU6iFA/0KiOmhkTVhe8oRoTBiTVPZu09x3vCra47+w8Yz1+2Q==
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
@@ -2167,6 +2184,13 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   dependencies:
     mime-types "~2.1.24"
     negotiator "0.6.2"
+
+acorn-dynamic-import@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-3.0.0.tgz#901ceee4c7faaef7e07ad2a47e890675da50a278"
+  integrity sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==
+  dependencies:
+    acorn "^5.0.0"
 
 acorn-globals@^6.0.0:
   version "6.0.0"
@@ -2185,6 +2209,11 @@ acorn-walk@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+
+acorn@^5.0.0, acorn@^5.5.3:
+  version "5.7.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.4.tgz#3e8d8a9947d0599a1796d10225d7432f4a4acf5e"
+  integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
 acorn@^6.4.1:
   version "6.4.2"
@@ -2274,7 +2303,7 @@ amd-name-resolver@1.2.0:
   dependencies:
     ensure-posix-path "^1.0.1"
 
-amd-name-resolver@^1.3.1:
+amd-name-resolver@^1.2.0, amd-name-resolver@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/amd-name-resolver/-/amd-name-resolver-1.3.1.tgz#ffe71c683c6e7191fc4ae1bb3aaed15abea135d9"
   integrity sha512-26qTEWqZQ+cxSYygZ4Cf8tsjDBLceJahhtewxtKZA3SRa4PluuqYCuheemDQD+7Mf5B7sr+zhTDWAHDh02a1Dw==
@@ -3811,7 +3840,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0, broccoli-plugin@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
   integrity sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==
@@ -3843,6 +3872,23 @@ broccoli-plugin@^4.0.0, broccoli-plugin@^4.0.1, broccoli-plugin@^4.0.2, broccoli
     quick-temp "^0.1.8"
     rimraf "^3.0.2"
     symlink-or-copy "^1.3.1"
+
+broccoli-rollup@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-rollup/-/broccoli-rollup-2.1.1.tgz#0b77dc4b7560a53e998ea85f3b56772612d4988d"
+  integrity sha512-aky/Ovg5DbsrsJEx2QCXxHLA6ZR+9u1TNVTf85soP4gL8CjGGKQ/JU8R3BZ2ntkWzo6/83RCKzX6O+nlNKR5MQ==
+  dependencies:
+    "@types/node" "^9.6.0"
+    amd-name-resolver "^1.2.0"
+    broccoli-plugin "^1.2.1"
+    fs-tree-diff "^0.5.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    magic-string "^0.24.0"
+    node-modules-path "^1.0.1"
+    rollup "^0.57.1"
+    symlink-or-copy "^1.1.8"
+    walk-sync "^0.3.1"
 
 broccoli-rollup@^4.1.1:
   version "4.1.1"
@@ -3921,6 +3967,17 @@ broccoli-string-replace@^0.1.1:
   dependencies:
     broccoli-persistent-filter "^1.1.5"
     minimatch "^3.0.3"
+
+broccoli-templater@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/broccoli-templater/-/broccoli-templater-2.0.2.tgz#285a892071c0b3ad5ebc275d9e8b3465e2d120d6"
+  integrity sha512-71KpNkc7WmbEokTQpGcbGzZjUIY1NSVa3GB++KFKAfx5SZPUozCOsBlSTwxcv8TLoCAqbBnsX5AQPgg6vJ2l9g==
+  dependencies:
+    broccoli-plugin "^1.3.1"
+    fs-tree-diff "^0.5.9"
+    lodash.template "^4.4.0"
+    rimraf "^2.6.2"
+    walk-sync "^0.3.3"
 
 broccoli-uglify-sourcemap@^3.1.0:
   version "3.2.0"
@@ -4047,6 +4104,17 @@ browserslist@^3.2.6:
   dependencies:
     caniuse-lite "^1.0.30000844"
     electron-to-chromium "^1.3.47"
+
+browserslist@^4.0.0:
+  version "4.16.8"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.8.tgz#cb868b0b554f137ba6e33de0ecff2eda403c4fb0"
+  integrity sha512-sc2m9ohR/49sWEbPj14ZSSZqp+kbi16aLao42Hmn3Z8FpjuMaq2xCA2l4zl9ITfyzvnvyE0hcg62YkIGKxgaNQ==
+  dependencies:
+    caniuse-lite "^1.0.30001251"
+    colorette "^1.3.0"
+    electron-to-chromium "^1.3.811"
+    escalade "^3.1.1"
+    node-releases "^1.1.75"
 
 browserslist@^4.16.6:
   version "4.16.6"
@@ -4268,6 +4336,21 @@ can-symlink@^1.0.0:
   integrity sha1-l7YH2KhLtsbiKLkC2GTstZS50hk=
   dependencies:
     tmp "0.0.28"
+
+caniuse-api@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/caniuse-api/-/caniuse-api-3.0.0.tgz#5e4d90e2274961d46291997df599e3ed008ee4c0"
+  integrity sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==
+  dependencies:
+    browserslist "^4.0.0"
+    caniuse-lite "^1.0.0"
+    lodash.memoize "^4.1.2"
+    lodash.uniq "^4.5.0"
+
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001251:
+  version "1.0.30001252"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz#cb16e4e3dafe948fc4a9bb3307aea054b912019a"
+  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
 
 caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001219:
   version "1.0.30001239"
@@ -4614,6 +4697,11 @@ colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
+colorette@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.3.0.tgz#ff45d2f0edb244069d3b772adeb04fed38d0a0af"
+  integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
 
 colors@1.0.3:
   version "1.0.3"
@@ -5019,6 +5107,13 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+date-time@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"
+  integrity sha512-/9+C44X7lot0IeiyfgJmETtRMhBidBYM2QFFIkGa0U1k+hSyY87Nw7PY3eDqpvCBm7I3WCSfPeZskW/YYq6m4g==
+  dependencies:
+    time-zone "^1.0.0"
+
 debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -5303,6 +5398,11 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.723:
   version "1.3.756"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.756.tgz#942cee59cd64d19f576d8d5804eef09cb423740c"
   integrity sha512-WsmJym1TMeHVndjPjczTFbnRR/c4sbzg8fBFtuhlb2Sru3i/S1VGpzDSrv/It8ctMU2bj8G7g7/O3FzYMGw6eA==
+
+electron-to-chromium@^1.3.811:
+  version "1.3.827"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.827.tgz#c725e8db8c5be18b472a919e5f57904512df0fc1"
+  integrity sha512-ye+4uQOY/jbjRutMcE/EmOcNwUeo1qo9aKL2tPyb09cU3lmxNeyDF4RWiemmkknW+p29h7dyDqy02higTxc9/A==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -5745,6 +5845,26 @@ ember-export-application-global@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.1.tgz#b120a70e322ab208defc9e2daebe8d0dfc2dcd46"
   integrity sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==
+
+ember-fetch@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/ember-fetch/-/ember-fetch-8.1.1.tgz#d68d4a58529121a572ec09c39c6a3ad174c83a2e"
+  integrity sha512-Xi1wNmPtVmfIoFH675AA0ELIdYUcoZ2p+6j9c8eDFjiGJiFesyp01bDtl5ryBI/1VPOByJLsDkT+4C11HixsJw==
+  dependencies:
+    abortcontroller-polyfill "^1.7.3"
+    broccoli-concat "^4.2.5"
+    broccoli-debug "^0.6.5"
+    broccoli-merge-trees "^4.2.0"
+    broccoli-rollup "^2.1.1"
+    broccoli-stew "^3.0.0"
+    broccoli-templater "^2.0.1"
+    calculate-cache-key-for-tree "^2.0.0"
+    caniuse-api "^3.0.0"
+    ember-cli-babel "^7.23.1"
+    ember-cli-typescript "^4.1.0"
+    ember-cli-version-checker "^5.1.2"
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.6.2"
 
 ember-inflector@^4.0.2:
   version "4.0.2"
@@ -6955,7 +7075,7 @@ fs-minipass@^2.0.0:
   dependencies:
     minipass "^3.0.0"
 
-fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6:
+fs-tree-diff@^0.5.2, fs-tree-diff@^0.5.3, fs-tree-diff@^0.5.4, fs-tree-diff@^0.5.6, fs-tree-diff@^0.5.9:
   version "0.5.9"
   resolved "https://registry.yarnpkg.com/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz#a4ec6182c2f5bd80b9b83c8e23e4522e6f5fd946"
   integrity sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==
@@ -8263,6 +8383,13 @@ is-redirect@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
   integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
 
+is-reference@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
+
 is-regex@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
@@ -8776,6 +8903,11 @@ loader.js@^4.2.3:
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.7.0.tgz#a1a52902001c83631efde9688b8ab3799325ef1f"
   integrity sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==
 
+locate-character@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-2.0.5.tgz#f2d2614d49820ecb3c92d80d193b8db755f74c0f"
+  integrity sha512-n2GmejDXtOPBAZdIiEFy5dJ5N38xBCXLNOtw2WpB9kGh6pnrEuKlwYI+Tkpofc4wDtVXHtoAOJaMRlYG/oYaxg==
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -8944,6 +9076,11 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.memoize@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
+  integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
 lodash.merge@^4.6.0, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -8959,7 +9096,7 @@ lodash.restparam@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
-lodash.template@^4.5.0:
+lodash.template@^4.4.0, lodash.template@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
   integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
@@ -8979,7 +9116,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash.uniq@^4.2.0:
+lodash.uniq@^4.2.0, lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
@@ -9066,6 +9203,13 @@ macos-release@^2.2.0, macos-release@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-2.5.0.tgz#067c2c88b5f3fb3c56a375b2ec93826220fa1ff2"
   integrity sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==
+
+magic-string@^0.24.0:
+  version "0.24.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.24.1.tgz#7e38e5f126cae9f15e71f0cf8e450818ca7d5a8f"
+  integrity sha512-YBfNxbJiixMzxW40XqJEIldzHyh5f7CZKalo1uZffevyrPEX8Qgo9s0dmcORLHdV47UyvJg8/zD+6hQG3qvJrA==
+  dependencies:
+    sourcemap-codec "^1.4.1"
 
 magic-string@^0.25.7:
   version "0.25.7"
@@ -9737,6 +9881,11 @@ node-releases@^1.1.71:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
+node-releases@^1.1.75:
+  version "1.1.75"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.75.tgz#6dd8c876b9897a1b8e5a02de26afa79bb54ebbfe"
+  integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
+
 node-watch@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/node-watch/-/node-watch-0.7.1.tgz#0caaa6a6833b0d533487f953c52a6c787769ba7c"
@@ -10226,6 +10375,11 @@ parse-json@5.2.0, parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-ms@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-1.0.1.tgz#56346d4749d78f23430ca0c713850aef91aa361d"
+  integrity sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
@@ -10483,6 +10637,13 @@ prettier@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.2.tgz#ef280a05ec253712e486233db5c6f23441e7342d"
   integrity sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==
+
+pretty-ms@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-3.2.0.tgz#87a8feaf27fc18414d75441467d411d6e6098a25"
+  integrity sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==
+  dependencies:
+    parse-ms "^1.0.0"
 
 printf@^0.6.1:
   version "0.6.1"
@@ -11084,6 +11245,11 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+  integrity sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -11253,12 +11419,29 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-pluginutils@^2.8.1:
+rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.8.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
   integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
   dependencies:
     estree-walker "^0.6.1"
+
+rollup@^0.57.1:
+  version "0.57.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.57.1.tgz#0bb28be6151d253f67cf4a00fea48fb823c74027"
+  integrity sha512-I18GBqP0qJoJC1K1osYjreqA8VAKovxuI3I81RSk0Dmr4TgloI0tAULjZaox8OsJ+n7XRrhH6i0G2By/pj1LCA==
+  dependencies:
+    "@types/acorn" "^4.0.3"
+    acorn "^5.5.3"
+    acorn-dynamic-import "^3.0.0"
+    date-time "^2.1.0"
+    is-reference "^1.1.0"
+    locate-character "^2.0.5"
+    pretty-ms "^3.1.0"
+    require-relative "^0.8.7"
+    rollup-pluginutils "^2.0.1"
+    signal-exit "^3.0.2"
+    sourcemap-codec "^1.4.1"
 
 rollup@^1.12.0:
   version "1.32.1"
@@ -11778,7 +11961,7 @@ source-map@~0.1.x:
   dependencies:
     amdefine ">=0.0.4"
 
-sourcemap-codec@^1.4.4:
+sourcemap-codec@^1.4.1, sourcemap-codec@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
@@ -12332,6 +12515,11 @@ through@~2.2.0, through@~2.2.7:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
   integrity sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=
+
+time-zone@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/time-zone/-/time-zone-1.0.0.tgz#99c5bf55958966af6d06d83bdf3800dc82faec5d"
+  integrity sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=
 
 timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"
@@ -13057,6 +13245,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
We were not testing against IE11, and a few failures had snuck in. We now only create m3 array proxies when we are able to instantiate a Proxy class, similarly to how Ember does it https://github.com/emberjs/ember.js/blob/v3.28.0/packages/@ember/-internals/utils/lib/proxy-utils.ts