### PR TITLE
Do not target IE in the perf app

### DIFF
--- a/m3-perf-testing-app/config/targets.js
+++ b/m3-perf-testing-app/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
We want to use a smallerr/faster build that does not include IE, as that is what most of our consumers will be doing