### PR TITLE
Unify `isDeleted`, `isNew` and `isDeletionCommitted` flag handling on Record Data

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -177,10 +177,13 @@ export default class M3RecordData {
       if (!baseRecordData && !parentRecordData && id) {
         this.globalM3CacheRD[this.id] = this;
       }
-      this._isNew = false;
-      this._isDeleted = false;
+      // We keep the state of the lifecycle flags on the base RD, and projections read from there
+      if (!baseRecordData) {
+        this._isNew = false;
+        this._isDeleted = false;
+        this._isDeletionCommitted = false;
+      }
       this._isLoaded = false;
-      this._isDeletionCommited = false;
     } else {
       this._embeddedInternalModel = null;
     }
@@ -349,9 +352,8 @@ export default class M3RecordData {
   didCommit(jsonApiResource, notifyRecord = false) {
     if (CUSTOM_MODEL_CLASS) {
       this._isNew = false;
-      if (this._isDeleted) {
-        this._isDeletionCommited = true;
-        this.removeFromRecordArrays();
+      if (this.isDeleted()) {
+        this.setIsDeletionCommitted(true);
       }
     }
     if (jsonApiResource && jsonApiResource.id) {
@@ -479,7 +481,18 @@ export default class M3RecordData {
   }
 
   isNew() {
+    if (this._baseRecordData) {
+      return this._baseRecordData.isNew();
+    }
     return this._isNew;
+  }
+
+  setIsNew(value) {
+    if (this._baseRecordData) {
+      return this._baseRecordData.setIsNew(value);
+    }
+    this._isNew = value;
+    this._notifyStateChange();
   }
 
   setIsDeleted(value) {
@@ -487,6 +500,7 @@ export default class M3RecordData {
       return this._baseRecordData.setIsDeleted(value);
     }
     this._isDeleted = value;
+    this._notifyStateChange();
   }
 
   isDeleted() {
@@ -497,7 +511,33 @@ export default class M3RecordData {
   }
 
   isDeletionCommitted() {
-    return this._isDeletionCommited;
+    if (this._baseRecordData) {
+      return this._baseRecordData.isDeletionCommitted();
+    }
+    return this._isDeletionCommitted;
+  }
+
+  setIsDeletionCommitted(value) {
+    if (this._baseRecordData) {
+      return this._baseRecordData.setIsDeletionCommitted(value);
+    }
+    this._isDeletionCommitted = value;
+    this._notifyStateChange();
+  }
+
+  _notifyStateChange() {
+    let record = recordDataToRecordMap.get(this);
+    if (this.isDeletionCommitted()) {
+      this.removeFromRecordArrays();
+    }
+    if (record) {
+      record._updateCurrentState();
+    }
+    if (this._projections) {
+      for (let i = 1; i < this._projections.length; i++) {
+        this._projections[i]._notifyStateChange();
+      }
+    }
   }
 
   /**
@@ -723,7 +763,6 @@ export default class M3RecordData {
     let dirtyKeys = [];
     if (this.isDeleted()) {
       this.setIsDeleted(false);
-      dirtyKeys.push('isDeleted');
     }
     if (this.hasChangedAttributes()) {
       dirtyKeys = Object.keys(this._attributes);
@@ -747,9 +786,8 @@ export default class M3RecordData {
       }
     }
 
-    if (dirtyKeys.length === 0) {
-      // nothing dirty on this record and we've already handled nested records
-      return;
+    if (CUSTOM_MODEL_CLASS) {
+      this._notifyStateChange();
     }
 
     if (this._notifyProjectionProperties(dirtyKeys)) {

--- a/tests/unit/projections/writing-test.js
+++ b/tests/unit/projections/writing-test.js
@@ -458,6 +458,14 @@ for (let { name, setupTest } of setupTestPerSchema()) {
             },
           },
         });
+
+        let projectedPreview = this.store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+            attributes: {},
+          },
+        });
         // Base record
         let baseRecord = this.store.push({
           data: {
@@ -469,6 +477,30 @@ for (let { name, setupTest } of setupTestPerSchema()) {
           },
         });
 
+        // We need to get the `isDeleted` and `isDirty` values at the start so we can assert that they invalidate properly
+        assert.equal(baseRecord.get('isDeleted'), false, 'The base model starts off not deleted');
+        assert.equal(
+          projectedExcerpt.get('isDeleted'),
+          false,
+          'The first projection starts off non deleted'
+        );
+        assert.equal(
+          projectedPreview.get('isDeleted'),
+          false,
+          'The other projection starts off not deleted'
+        );
+        assert.equal(
+          projectedExcerpt.get('isDirty'),
+          false,
+          'The first projection starts off not dirty'
+        );
+        assert.equal(baseRecord.get('isDirty'), false, 'The base model starts off not dirty');
+        assert.equal(
+          projectedPreview.get('isDirty'),
+          false,
+          'The other projection starts off not deleted'
+        );
+
         projectedExcerpt.deleteRecord();
 
         assert.equal(
@@ -476,8 +508,16 @@ for (let { name, setupTest } of setupTestPerSchema()) {
           true,
           'The projection is in a deleted state'
         );
-
         assert.equal(baseRecord.get('isDeleted'), true, 'The base model is also deleted');
+        assert.equal(projectedPreview.get('isDeleted'), true, 'The other projection is deleted');
+
+        assert.equal(projectedExcerpt.get('isDirty'), true, 'The projection is in a dirty state');
+        assert.equal(baseRecord.get('isDirty'), true, 'The base model is also dirty');
+        assert.equal(
+          projectedPreview.get('isDirty'),
+          true,
+          'The other projection is also in a dirty state'
+        );
 
         projectedExcerpt.rollbackAttributes();
 
@@ -486,8 +526,24 @@ for (let { name, setupTest } of setupTestPerSchema()) {
           false,
           'The projection has been rolled back'
         );
-
         assert.equal(baseRecord.get('isDeleted'), false, 'The base model has been rolled back');
+        assert.equal(
+          projectedPreview.get('isDeleted'),
+          false,
+          'The other projection has been rolled back'
+        );
+
+        assert.equal(
+          projectedExcerpt.get('isDirty'),
+          false,
+          'The first projection is no longer dirty'
+        );
+        assert.equal(baseRecord.get('isDirty'), false, 'The base model is no longer dirty');
+        assert.equal(
+          projectedPreview.get('isDirty'),
+          false,
+          'The other projection is no longer dirty'
+        );
       });
 
       test('Base models share the deleted value with the projections', function (assert) {
@@ -514,6 +570,38 @@ for (let { name, setupTest } of setupTestPerSchema()) {
           },
         });
 
+        let projectedPreview = this.store.push({
+          data: {
+            id: BOOK_ID,
+            type: BOOK_PREVIEW_PROJECTION_CLASS_PATH,
+            attributes: {},
+          },
+        });
+
+        assert.equal(baseRecord.get('isDeleted'), false, 'The base model starts off not deleted');
+        assert.equal(
+          projectedExcerpt.get('isDeleted'),
+          false,
+          'The projection starts off non deleted'
+        );
+        assert.equal(
+          projectedPreview.get('isDeleted'),
+          false,
+          'The other projection starts off not deleted'
+        );
+
+        assert.equal(
+          projectedExcerpt.get('isDirty'),
+          false,
+          'The first projection starts off not dirty'
+        );
+        assert.equal(baseRecord.get('isDirty'), false, 'The base model starts off not dirty');
+        assert.equal(
+          projectedPreview.get('isDirty'),
+          false,
+          'The other projection starts off not deleted'
+        );
+
         baseRecord.deleteRecord();
 
         assert.equal(
@@ -521,8 +609,16 @@ for (let { name, setupTest } of setupTestPerSchema()) {
           true,
           'The projection is in a deleted state'
         );
-
         assert.equal(baseRecord.get('isDeleted'), true, 'The base model is also deleted');
+        assert.equal(projectedPreview.get('isDeleted'), true, 'The other projection is deleted');
+
+        assert.equal(projectedExcerpt.get('isDirty'), true, 'The projection is in a dirty state');
+        assert.equal(baseRecord.get('isDirty'), true, 'The base model is also dirty');
+        assert.equal(
+          projectedPreview.get('isDirty'),
+          true,
+          'The other projection is also in a dirty state'
+        );
 
         baseRecord.rollbackAttributes();
 
@@ -531,8 +627,24 @@ for (let { name, setupTest } of setupTestPerSchema()) {
           false,
           'The projection has been rolled back'
         );
-
         assert.equal(baseRecord.get('isDeleted'), false, 'The base model has been rolled back');
+        assert.equal(
+          projectedPreview.get('isDeleted'),
+          false,
+          'The other projection has been rolled back'
+        );
+
+        assert.equal(
+          projectedExcerpt.get('isDirty'),
+          false,
+          'The first projection is no longer dirty'
+        );
+        assert.equal(baseRecord.get('isDirty'), false, 'The base model is no longer dirty');
+        assert.equal(
+          projectedPreview.get('isDirty'),
+          false,
+          'The other projection is no longer dirty'
+        );
       });
     }
 

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -902,6 +902,7 @@ for (let testRun = 0; testRun < 2; testRun++) {
 
           this.child1Model = {
             _notifyProperties: this.sinon.spy(),
+            _updateCurrentState: () => {},
           };
 
           this.child1RecordData = this.topRecordData._getChildRecordData(
@@ -918,6 +919,7 @@ for (let testRun = 0; testRun < 2; testRun++) {
 
           this.child2Model = {
             _notifyProperties: this.sinon.spy(),
+            _updateCurrentState: () => {},
           };
           this.child2RecordData = this.topRecordData._getChildRecordData(
             'child2',
@@ -932,6 +934,7 @@ for (let testRun = 0; testRun < 2; testRun++) {
 
           this.child11Model = {
             _notifyProperties: this.sinon.spy(),
+            _updateCurrentState: () => {},
           };
           this.child11RecordData = this.child1RecordData._getChildRecordData(
             'child1_1',


### PR DESCRIPTION
Building upon #1301, we now always keep record state flags on the `baseRecordData` and notify the record and projections when they change, having a unidirectional data flow. This is more robust, and fixes bugs where projections would get their state out of sync.