### PR TITLE
Add support for Node v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12.x, 14.x] # Active LTS
+        node: [12.x, 14.x, 16.x] # Active and Current LTS
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "testem": "^3.5.0"
   },
   "engines": {
-    "node": ">= 12.* < 16.*"
+    "node": ">= 12.* <= 16.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Node v16 is It is moving from current to active on October 26, we should allow it so people can test their apps with the upcoming node LTS