### PR TITLE
Fix for tracked properties updating when using m3 native properties

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -115,20 +115,20 @@ if (CUSTOM_MODEL_CLASS) {
       // to trigger `unknownProperty`, as otherwise we will end up in an infinite loop
       // of repeatadly calling `receiver.get`
 
-     if (this.getting === key) {
-       return undefined;
-     }
-     
-     let shouldReset = this.getting === '';
-     this.getting = key;
-     
-     try {
-       return get(receiver, key);
-     } finally {
-       if (shouldReset) {
-         this.getting = '';
-       }
-     }
+      if (this.getting === key) {
+        return undefined;
+      }
+
+      let shouldReset = this.getting === '';
+      this.getting = key;
+
+      try {
+        return get(receiver, key);
+      } finally {
+        if (shouldReset) {
+          this.getting = '';
+        }
+      }
     }
 
     set(target, key, value, receiver) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -115,14 +115,20 @@ if (CUSTOM_MODEL_CLASS) {
       // to trigger `unknownProperty`, as otherwise we will end up in an infinite loop
       // of repeatadly calling `receiver.get`
 
-      if (!DEBUG) {
-        if (this.getting === key) {
-          this.getting = undefined;
-          return undefined;
-        }
-        this.getting = key;
-      }
-      return get(receiver, key);
+     if (this.getting === key) {
+       return undefined;
+     }
+     
+     let shouldReset = this.getting === '';
+     this.getting = key;
+     
+     try {
+       return get(receiver, key);
+     } finally {
+       if (shouldReset) {
+         this.getting = '';
+       }
+     }
     }
 
     set(target, key, value, receiver) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -80,7 +80,7 @@ let megamorphicModelProxyHandler, megamorphicNativeDeprecationHandler;
 
 if (CUSTOM_MODEL_CLASS) {
   const MegamorphicModelProxyHandler = class {
-    this.getting = '';
+    getting = '';
 
     get(target, key, receiver) {
       if (typeof key !== 'string' || key in target) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -80,9 +80,7 @@ let megamorphicModelProxyHandler, megamorphicNativeDeprecationHandler;
 
 if (CUSTOM_MODEL_CLASS) {
   const MegamorphicModelProxyHandler = class {
-    constructor() {
-      this.getting = '';
-    }
+    this.getting = '';
 
     get(target, key, receiver) {
       if (typeof key !== 'string' || key in target) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -80,6 +80,10 @@ let megamorphicModelProxyHandler, megamorphicNativeDeprecationHandler;
 
 if (CUSTOM_MODEL_CLASS) {
   const MegamorphicModelProxyHandler = class {
+    constructor() {
+      this.getting = '';
+    }
+
     get(target, key, receiver) {
       if (typeof key !== 'string' || key in target) {
         return Reflect.get(target, key, receiver);
@@ -88,19 +92,39 @@ if (CUSTOM_MODEL_CLASS) {
       // Ideally we would do `receiver.unknownProperty(key)` here, but
       // unfortunately `unknownProperty` does not entangle the property
       // tag. `Ember.get` is the only thing that does, actually, so we
-      // have to use it. This is safe, because we already checked that the
-      // property is not `in` the instance, so it will definitely call
-      // `unknownProperty` and will not re-enter.
+      // have to use it. However we need to be careful that we do not end
+      // up in an infinite loop when relying on `Ember.get` calling
+      // `.unknownProperty`
 
-      // We have to use `target.get` instead of `receiver.get` because
-      // `Ember.get` will access the property itself before calling
-      // `unknownProperty` causing an infinite recursion
+      // `Ember.get` is going to check whether `receiver` has the `key`
+      // property defined, and if not, call `.unknownProperty`
 
-      // The only potential downside here is that the value of `this` in our
-      // `unknownProperty` handler will be set to the target MegamorphicModel
-      //  and not to the proxy, so we have to be careful when accessing WeakMaps
-      // inside our `unknonwProperty` code, but there isn't a user visible impact
-      return target.get(key);
+      // However, the way that check is implemented differs slightly
+      // between the DEBUG and production ember builds.
+      // See: https://github.com/emberjs/ember.js/blob/3ce13cea235cde8a87d89473533c453523412764/packages/%40ember/-internals/metal/lib/property_get.ts#L110
+
+      // In DEBUG, Ember will have it's own debug proxies installed before this proxy,
+      // and Ember's proxy will have stashed the `target` (in this case the m3 model) under a symbol.
+      // See: https://github.com/emberjs/ember.js/blob/3ce13cea235cde8a87d89473533c453523412764/packages/%40ember/-internals/metal/lib/property_get.ts#L22
+      // To check whether it should call `unknonwnProperty`, `Ember.get` will check for property existance
+      // on the stashed target. Because we have already checked that `key` is not `in target`,
+      // we know the target check will return false, and we are not going re-enter and cause an infinite loop.
+
+      // In production, without Ember's debug Proxies, we will go through
+      // a more straightforward path, where `Ember.get` will do a `receiver[key]` check
+      // to decided whether to call `.unknownProperty`. In that case, we need to make sure
+      // that the second time this getter is called with the key, we return `undefined`
+      // to trigger `unknownProperty`, as otherwise we will end up in an infinite loop
+      // of repeatadly calling `receiver.get`
+
+      if (!DEBUG) {
+        if (this.getting === key) {
+          this.getting = undefined;
+          return undefined;
+        }
+        this.getting = key;
+      }
+      return get(receiver, key);
     }
 
     set(target, key, value, receiver) {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@ember-data/store": "3.28.3",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.5.0",
+    "@glimmer/component": "^1.0.4",
     "@malleatus/nyx": "^0.2.0",
     "@octokit/rest": "^18.12.0",
     "babel-eslint": "^10.1.0",
@@ -152,7 +153,7 @@
     }
   },
   "volta": {
-    "node": "14.8.0",
+    "node": "14.18.1",
     "yarn": "1.22.10"
   }
 }

--- a/tests/unit/model/native-access/native-access-arrays-test.js
+++ b/tests/unit/model/native-access/native-access-arrays-test.js
@@ -39,7 +39,7 @@ class TestSchema extends DefaultSchema {
 }
 
 if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
-  module(`unit/model/native-access-arrays`, function (hooks) {
+  module(`unit/model/native-access/native-access-arrays`, function (hooks) {
     setupTest(hooks);
 
     hooks.beforeEach(function () {

--- a/tests/unit/model/native-access/native-access-test.js
+++ b/tests/unit/model/native-access/native-access-test.js
@@ -21,7 +21,7 @@ if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
     }
   }
 
-  module('unit/model/native-access', function (hooks) {
+  module('unit/model/native-access/native-access', function (hooks) {
     setupTest(hooks);
 
     hooks.beforeEach(function () {

--- a/tests/unit/model/native-access/tracked-properties-test.js
+++ b/tests/unit/model/native-access/tracked-properties-test.js
@@ -72,7 +72,43 @@ if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
       await settled();
 
       renderedTitle = this.element.querySelector('.title').innerText;
-      assert.equal(renderedTitle, 'Title: New title', 'component is rendered correctly');
+      assert.equal(renderedTitle, 'Title: New title', 'component is updated correctly');
+    });
+
+    test('Template getters which depend on m3 native properties update correctly', async function (assert) {
+      this.owner.register('service:m3-schema', TestSchema);
+      this.owner.register(
+        'template:components/show-book',
+        hbs`<h1 class="title">{{@model.title}}</h1>
+    `
+      );
+
+      this.store.push({
+        data: {
+          id: 'urn:li:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            title: 'How to Win Friends and Influence People',
+          },
+        },
+      });
+
+      let book = (this.book = this.store.peekRecord('com.example.bookstore.Book', 'urn:li:book:1'));
+      await render(hbs`
+        {{show-book model=this.book}}
+      `);
+
+      let renderedTitle = this.element.querySelector('.title').innerText;
+      assert.equal(
+        renderedTitle,
+        'How to Win Friends and Influence People',
+        'template is rendered correctly'
+      );
+      book.title = 'New title';
+      await settled();
+
+      renderedTitle = this.element.querySelector('.title').innerText;
+      assert.equal(renderedTitle, 'New title', 'template is updated correctly');
     });
 
     test('Component getters which depend on m3 native properties update acrross nested models correctly', async function (assert) {
@@ -134,7 +170,7 @@ if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
       await settled();
 
       renderedTitle = this.element.querySelector('.title').innerText;
-      assert.equal(renderedTitle, 'Title: New title', 'component is rendered correctly');
+      assert.equal(renderedTitle, 'Title: New title', 'component is updated correctly');
     });
   });
 }

--- a/tests/unit/model/native-access/tracked-properties-test.js
+++ b/tests/unit/model/native-access/tracked-properties-test.js
@@ -1,0 +1,140 @@
+import { test, module } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
+import HAS_NATIVE_PROXY from 'ember-m3/utils/has-native-proxy';
+import Component from '@glimmer/component';
+import hbs from 'htmlbars-inline-precompile';
+import { render, settled } from '@ember/test-helpers';
+
+if (CUSTOM_MODEL_CLASS && HAS_NATIVE_PROXY) {
+  class TestSchema extends DefaultSchema {
+    includesModel(modelName) {
+      return /^com.example.bookstore\./i.test(modelName);
+    }
+    setAttribute(modelName, attr, value, schemaInterface) {
+      schemaInterface.setAttr(attr, value);
+    }
+    useNativeProperties() {
+      return true;
+    }
+  }
+
+  module('unit/model/native-access/tracked-properties', function (hooks) {
+    setupRenderingTest(hooks);
+
+    hooks.beforeEach(function () {
+      this.store = this.owner.lookup('service:store');
+    });
+
+    test('Component getters which depend on m3 native properties update correctly', async function (assert) {
+      this.owner.register('service:m3-schema', TestSchema);
+      this.owner.register(
+        'template:components/show-book',
+        hbs`<h1 class="title">{{this.formattedTitle}}</h1>
+    `
+      );
+
+      this.owner.register(
+        'component:show-book',
+        class ShowBookComponent extends Component {
+          constructor() {
+            super(...arguments);
+          }
+          get formattedTitle() {
+            return `Title: ${this.args.model.title}`;
+          }
+        }
+      );
+
+      this.store.push({
+        data: {
+          id: 'urn:li:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            title: 'How to Win Friends and Influence People',
+          },
+        },
+      });
+
+      let book = (this.book = this.store.peekRecord('com.example.bookstore.Book', 'urn:li:book:1'));
+      await render(hbs`
+        {{show-book model=this.book}}
+      `);
+
+      let renderedTitle = this.element.querySelector('.title').innerText;
+      assert.equal(
+        renderedTitle,
+        'Title: How to Win Friends and Influence People',
+        'component is rendered correctly'
+      );
+      book.title = 'New title';
+      await settled();
+
+      renderedTitle = this.element.querySelector('.title').innerText;
+      assert.equal(renderedTitle, 'Title: New title', 'component is rendered correctly');
+    });
+
+    test('Component getters which depend on m3 native properties update acrross nested models correctly', async function (assert) {
+      this.owner.register('service:m3-schema', TestSchema);
+      this.owner.register(
+        'template:components/show-book',
+        hbs`<h1 class="title">{{this.formattedTitle}}</h1>
+  `
+      );
+      class NestedSchema extends TestSchema {
+        computeAttribute(key, value, modelName, schemaInterface) {
+          if (key === 'chapter') {
+            return schemaInterface.nested({
+              attributes: value,
+            });
+          }
+          return value;
+        }
+      }
+
+      this.owner.register('service:m3-schema', NestedSchema);
+
+      this.owner.register(
+        'component:show-book',
+        class ShowBookComponent extends Component {
+          constructor() {
+            super(...arguments);
+          }
+          get formattedTitle() {
+            return `Title: ${this.args.model.chapter.title}`;
+          }
+        }
+      );
+
+      this.store.push({
+        data: {
+          id: 'urn:li:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            chapter: {
+              title: 'How to Win Friends and Influence People',
+            },
+          },
+        },
+      });
+
+      let book = (this.book = this.store.peekRecord('com.example.bookstore.Book', 'urn:li:book:1'));
+      await render(hbs`
+        {{show-book model=this.book}}
+      `);
+
+      let renderedTitle = this.element.querySelector('.title').innerText;
+      assert.equal(
+        renderedTitle,
+        'Title: How to Win Friends and Influence People',
+        'component is rendered correctly'
+      );
+      book.chapter.title = 'New title';
+      await settled();
+
+      renderedTitle = this.element.querySelector('.title').innerText;
+      assert.equal(renderedTitle, 'Title: New title', 'component is rendered correctly');
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,12 +60,28 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.15.4":
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.8.tgz#fa56be6b596952ceb231048cf84ee499a19c0cd1"
+  integrity sha512-ECmAKstXbp1cvpTTZciZCgfOt6iN64lR0d+euv3UZisU5awfRawOvg07Utn/qBGuH4bRIEZKrA/4LzZyXhZr8g==
+  dependencies:
+    "@babel/types" "^7.15.6"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
 "@babel/helper-annotate-as-pure@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz#7bf478ec3b71726d56a8ca5775b046fc29879e61"
   integrity sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-annotate-as-pure@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz#3d0e43b00c5e49fdb6c57e421601a7a658d5f835"
+  integrity sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.14.5":
   version "7.14.5"
@@ -96,6 +112,18 @@
     "@babel/helper-optimise-call-expression" "^7.14.5"
     "@babel/helper-replace-supers" "^7.14.5"
     "@babel/helper-split-export-declaration" "^7.14.5"
+
+"@babel/helper-create-class-features-plugin@^7.5.5":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz#7f977c17bd12a5fba363cb19bea090394bf37d2e"
+  integrity sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.15.4"
+    "@babel/helper-function-name" "^7.15.4"
+    "@babel/helper-member-expression-to-functions" "^7.15.4"
+    "@babel/helper-optimise-call-expression" "^7.15.4"
+    "@babel/helper-replace-supers" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
 
 "@babel/helper-create-regexp-features-plugin@^7.14.5":
   version "7.14.5"
@@ -135,12 +163,28 @@
     "@babel/template" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-function-name@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz#845744dafc4381a4a5fb6afa6c3d36f98a787ebc"
+  integrity sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.15.4"
+    "@babel/template" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-get-function-arity@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
   integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-get-function-arity@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz#098818934a137fce78b536a3e015864be1e2879b"
+  integrity sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-hoist-variables@^7.14.5":
   version "7.14.5"
@@ -149,12 +193,26 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-hoist-variables@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz#09993a3259c0e918f99d104261dfdfc033f178df"
+  integrity sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-member-expression-to-functions@^7.14.5":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
   integrity sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-member-expression-to-functions@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz#bfd34dc9bba9824a4658b0317ec2fd571a51e6ef"
+  integrity sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.14.5", "@babel/helper-module-imports@^7.8.3":
   version "7.14.5"
@@ -198,6 +256,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-optimise-call-expression@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz#f310a5121a3b9cc52d9ab19122bd729822dee171"
+  integrity sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.13.0", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
@@ -221,6 +286,16 @@
     "@babel/helper-optimise-call-expression" "^7.14.5"
     "@babel/traverse" "^7.14.5"
     "@babel/types" "^7.14.5"
+
+"@babel/helper-replace-supers@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz#52a8ab26ba918c7f6dee28628b07071ac7b7347a"
+  integrity sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.15.4"
+    "@babel/helper-optimise-call-expression" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-simple-access@^7.14.5":
   version "7.14.5"
@@ -250,6 +325,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-split-export-declaration@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz#aecab92dcdbef6a10aa3b62ab204b085f776e257"
+  integrity sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-validator-identifier@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
@@ -259,6 +341,11 @@
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz#32be33a756f29e278a0d644fa08a2c9e0f88a34c"
   integrity sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow==
+
+"@babel/helper-validator-identifier@^7.14.9":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
+  integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -302,6 +389,11 @@
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.8.tgz#66fd41666b2d7b840bd5ace7f7416d5ac60208d4"
   integrity sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA==
+
+"@babel/parser@^7.15.4":
+  version "7.15.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.8.tgz#7bacdcbe71bdc3ff936d510c15dcea7cf0b99016"
+  integrity sha512-BRYa3wcQnjS/nqI8Ac94pYYpJfojHVvVXJ97+IDCImX4Jc8W8Xv1+47enbruk+q1etOpsQNwnfFcNGw+gtPGxA==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.14.5":
   version "7.14.5"
@@ -830,6 +922,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.2.0"
 
+"@babel/plugin-transform-typescript@~7.5.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.5.5.tgz#6d862766f09b2da1cb1f7d505fe2aedab6b7d4b8"
+  integrity sha512-pehKf4m640myZu5B2ZviLaiBlxMCjSZ1qTEO459AXKX5GnPueyulJeCqZFs1nz/Ya2dDzXQ1NxZ/kKNWyD4h6w==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.5.5"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
+
 "@babel/plugin-transform-unicode-escapes@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.14.5.tgz#9d4bd2a681e3c5d7acf4f57fa9e51175d91d0c6b"
@@ -966,6 +1067,15 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/template@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
+  integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/traverse@^7.1.6", "@babel/traverse@^7.12.1", "@babel/traverse@^7.13.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.0":
   version "7.14.7"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.7.tgz#64007c9774cfdc3abd23b0780bc18a3ce3631753"
@@ -996,6 +1106,21 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.4.tgz#ff8510367a144bfbff552d9e18e28f3e2889c22d"
+  integrity sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.4"
+    "@babel/helper-function-name" "^7.15.4"
+    "@babel/helper-hoist-variables" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.1.6", "@babel/types@^7.12.1", "@babel/types@^7.14.5", "@babel/types@^7.4.4", "@babel/types@^7.7.0", "@babel/types@^7.7.2":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
@@ -1010,6 +1135,14 @@
   integrity sha512-iob4soQa7dZw8nodR/KlOQkPh9S4I8RwCxwRIFuiMRYjOzH/KJzdUfDgz6cGi5dDaclXF4P2PAhCdrBJNIg68Q==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.8"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.15.4", "@babel/types@^7.15.6":
+  version "7.15.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.6.tgz#99abdc48218b2881c058dd0a7ab05b99c9be758f"
+  integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -1379,6 +1512,31 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@glimmer/component@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.0.4.tgz#1c85a5181615a6647f6acfaaed68e28ad7e9626e"
+  integrity sha512-sS4N8wtcKfYdUJ6O3m8nbTut6NjErdz94Ap8VB1ekcg4WSD+7sI7Nmv6kt2rdPoe363nUdjUbRBzHNWhLzraBw==
+  dependencies:
+    "@glimmer/di" "^0.1.9"
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/util" "^0.44.0"
+    broccoli-file-creator "^2.1.1"
+    broccoli-merge-trees "^3.0.2"
+    ember-cli-babel "^7.7.3"
+    ember-cli-get-component-path-option "^1.0.0"
+    ember-cli-is-package-missing "^1.0.0"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-path-utils "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-typescript "3.0.0"
+    ember-cli-version-checker "^3.1.3"
+    ember-compatibility-helpers "^1.1.2"
+
+"@glimmer/di@^0.1.9":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@glimmer/di/-/di-0.1.11.tgz#a6878c07a13a2c2c76fcde598a5c97637bfc4280"
+  integrity sha1-poeMB6E6LCx2/N5ZilyXY3v8QoA=
+
 "@glimmer/encoder@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.42.2.tgz#d3ba3dc9f1d4fa582d1d18b63da100fc5c664057"
@@ -1453,6 +1611,11 @@
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
   integrity sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==
+
+"@glimmer/util@^0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.44.0.tgz#45df98d73812440206ae7bda87cfe04aaae21ed9"
+  integrity sha512-duAsm30uVK9jSysElCbLyU6QQYO2X9iLDLBIBUcCqck9qN1o3tK2qWiHbGK5d6g8E2AJ4H88UrfElkyaJlGrwg==
 
 "@glimmer/validator@^0.44.0":
   version "0.44.0"
@@ -5513,7 +5676,7 @@ ember-cli-babel@^6.9.0:
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -5660,6 +5823,23 @@ ember-cli-test-loader@^3.0.0:
   integrity sha512-wfFRBrfO9gaKScYcdQxTfklx9yp1lWK6zv1rZRpkas9z2SHyJojF7NOQRWQgSB3ypm7vfpiF8VsFFVVr7VBzAQ==
   dependencies:
     ember-cli-babel "^7.13.2"
+
+ember-cli-typescript@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript/-/ember-cli-typescript-3.0.0.tgz#3b838d1ce9e4d22a98e68da22ceac6dc0cfd9bfc"
+  integrity sha512-lo5YArbJzJi5ssvaGqTt6+FnhTALnSvYVuxM7lfyL1UCMudyNJ94ovH5C7n5il7ATd6WsNiAPRUO/v+s5Jq/aA==
+  dependencies:
+    "@babel/plugin-transform-typescript" "~7.5.0"
+    ansi-to-html "^0.6.6"
+    debug "^4.0.0"
+    ember-cli-babel-plugin-helpers "^1.0.0"
+    execa "^2.0.0"
+    fs-extra "^8.0.0"
+    resolve "^1.5.0"
+    rsvp "^4.8.1"
+    semver "^6.0.0"
+    stagehand "^1.0.0"
+    walk-sync "^2.0.0"
 
 ember-cli-typescript@^2.0.2:
   version "2.0.2"
@@ -5834,7 +6014,7 @@ ember-cli@~3.28.3:
     workerpool "^6.1.4"
     yam "^1.0.0"
 
-ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
+ember-compatibility-helpers@^1.1.2, ember-compatibility-helpers@^1.2.0, ember-compatibility-helpers@^1.2.1, ember-compatibility-helpers@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.5.tgz#b8363b1d5b8725afa9a4fe2b2986ac28626c6f23"
   integrity sha512-7cddkQQp8Rs2Mqrj0xqZ0uO7eC9tBCKyZNcP2iE1RxQqOGPv8fiPkj1TUeidUB/Qe80lstoVXWMEuqqhW7Yy9A==
@@ -6479,6 +6659,21 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-2.1.0.tgz#e5d3ecd837d2a60ec50f3da78fd39767747bbe99"
+  integrity sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^3.0.0"
+    onetime "^5.1.0"
+    p-finally "^2.0.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 execa@^4.0.0, execa@^4.0.2:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
@@ -7043,7 +7238,7 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^8.0.1, fs-extra@^8.1.0:
+fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -10181,6 +10376,13 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
+npm-run-path@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-3.1.0.tgz#7f91be317f6a466efed3c9f2980ad8a4ee8b0fa5"
+  integrity sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==
+  dependencies:
+    path-key "^3.0.0"
+
 npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
@@ -10416,6 +10618,11 @@ p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
+p-finally@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-2.0.1.tgz#bd6fcaa9c559a096b680806f4d657b3f0f240561"
+  integrity sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==
 
 p-is-promise@^1.1.0:
   version "1.1.0"
@@ -13397,7 +13604,7 @@ walk-sync@^1.0.0, walk-sync@^1.1.3:
     ensure-posix-path "^1.1.0"
     matcher-collection "^1.1.1"
 
-walk-sync@^2.0.2, walk-sync@^2.2.0:
+walk-sync@^2.0.0, walk-sync@^2.0.2, walk-sync@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-2.2.0.tgz#80786b0657fcc8c0e1c0b1a042a09eae2966387a"
   integrity sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==


### PR DESCRIPTION
The fix in https://github.com/hjdivad/ember-m3/pull/1376 was not correct. In order to properly entangle we need to be doing `receiver.get` but to protect against re-entrance in production, we need to manually keep track of the key being accessed.