### PR TITLE
Update CI scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     name: performance-app
     needs: [lint]
     runs-on: ubuntu-latest
-    
+
     # run all of the commands below inside the perf test app
     defaults:
       run:
@@ -83,7 +83,7 @@ jobs:
       - name: yarn install
         run: yarn --frozen-lockfile --install
       - name: test:performance-app
-        run: yarn test 
+        run: yarn test
 
   test-node:
     name: 't:' # rely on matrix for most of name

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -32,8 +32,8 @@ module.exports = function () {
           name: 'ember-lts-n-1',
           npm: {
             devDependencies: {
-              'ember-source': '~3.12.0',
-              'ember-data': '~3.16.0',
+              'ember-source': '~3.24.0',
+              'ember-data': '~3.24.0',
               '@ember-data/store': null,
               '@ember-data/debug': null,
               '@ember-data/model': null,
@@ -48,8 +48,8 @@ module.exports = function () {
           name: 'ember-lts',
           npm: {
             devDependencies: {
-              'ember-source': '~3.16.0',
-              'ember-data': '~3.16.0',
+              'ember-source': '~3.28.0',
+              'ember-data': '~3.28.0',
               '@ember-data/store': null,
               '@ember-data/debug': null,
               '@ember-data/model': null,
@@ -115,8 +115,8 @@ module.exports = function () {
           name: 'release-n-1',
           npm: {
             devDependencies: {
-              'ember-source': '~3.17.0',
-              'ember-data': '~3.17.0',
+              'ember-source': '~3.28.0',
+              'ember-data': '~3.28.0',
               '@ember-data/store': null,
               '@ember-data/debug': null,
               '@ember-data/model': null,

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -64,7 +64,8 @@ module.exports = function () {
           name: 'ember-data-packages-latest',
           npm: {
             devDependencies: {
-              'ember-source': 'latest',
+              // TODO: change this back to `latest` once Ember 4 compatibility has landed
+              'ember-source': '^3.28.0',
               'ember-data': null,
               '@ember-data/store': 'latest',
               '@ember-data/debug': null, // available in 3.15
@@ -80,7 +81,8 @@ module.exports = function () {
           name: 'ember-data-packages-beta',
           npm: {
             devDependencies: {
-              'ember-source': 'latest',
+              // TODO: change this back to `latest` once Ember 4 compatibility has landed
+              'ember-source': '^3.28.0',
               'ember-data': null,
               '@ember-data/store': 'beta',
               '@ember-data/debug': 'beta',
@@ -96,7 +98,8 @@ module.exports = function () {
           name: 'ember-data-packages-canary',
           npm: {
             devDependencies: {
-              'ember-source': 'latest',
+              // TODO: change this back to `latest` once Ember 4 compatibility has landed
+              'ember-source': '^3.28.0',
               'ember-data': null,
               '@ember-data/store': 'canary',
               '@ember-data/debug': 'canary',

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -129,6 +129,8 @@ module.exports = function () {
         },
         {
           name: 'release-channel',
+          // TODO: Remove this when we land Ember 4 compatibility
+          allowedToFail: true,
           npm: {
             devDependencies: {
               'ember-source': urls[0],


### PR DESCRIPTION
- Builds on top of #1504 (to make rebasing easier and to see what is left)
- Use Ember 3.28 instead of `latest` in ember-try scenarios that are only trying to use a "recent" Ember version
- Update LTS / release try scenario versions (LTS => 3.28, LTS-1 => 3.24)
- Remove release-channel ember-try scenario (temporarily)
