### PR TITLE
[bugfix] ensure that errors can be updated when using useUnderlyingErrorsValue

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -741,6 +741,12 @@ export default class MegamorphicModel extends EmberObject {
     }
     return this._errors;
   }
+
+  set errors(value) {
+    if (this._schema.useUnderlyingErrorsValue(this._modelName)) {
+      return this.setUnknownProperty('errors', value);
+    }
+  }
 }
 
 MegamorphicModel.prototype.store = null;

--- a/addon/model.js
+++ b/addon/model.js
@@ -744,7 +744,12 @@ export default class MegamorphicModel extends EmberObject {
 
   set errors(value) {
     if (this._schema.useUnderlyingErrorsValue(this._modelName)) {
-      return this.setUnknownProperty('errors', value);
+      this.setUnknownProperty('errors', value);
+    } else {
+      this._errors.clear();
+      for (const error of value) {
+        this._errors.pushObject(error);
+      }
     }
   }
 }

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { run } from '@ember/runloop';
-import { get } from '@ember/object';
+import { get, set } from '@ember/object';
 import DefaultSchema from 'ember-m3/services/m3-schema';
 import { Errors as ModelErrors } from '@ember-data/model/-private';
 
@@ -159,6 +159,45 @@ module('unit/model/errors-attribute', function (hooks) {
     assert.ok(
       get(model, 'errors') instanceof ModelErrors,
       "schema's default useUnderlyingErrorsValue return value should return ModelsError object instance"
+    );
+  });
+
+  test('schema with flag set to true returns errors from payload and can be set', function (assert) {
+    this.owner.register('service:m3-schema', TestSchemaFlagOn);
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'urn:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            author: ['urn:author:1'],
+            errors: errorsArray,
+          },
+        },
+      });
+    });
+    assert.deepEqual(
+      get(model, 'errors').get('firstObject'),
+      errorsArray[0],
+      "schema's useUnderlyingErrorsValue returns true should return payload errors array"
+    );
+
+    set(model, 'errors', [
+      {
+        path: ['customErrorPath'],
+        locations: [{ column: 1, line: 3 }],
+        message: 'Error calling findByCustom.',
+      },
+    ]);
+    assert.deepEqual(
+      get(model, 'errors').get('firstObject'),
+      {
+        path: ['customErrorPath'],
+        locations: [{ column: 1, line: 3 }],
+        message: 'Error calling findByCustom.',
+      },
+      "schema's useUnderlyingErrorsValue returns true should return the custom errors array"
     );
   });
 });

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -141,6 +141,37 @@ module('unit/model/errors-attribute', function (hooks) {
     );
   });
 
+  test('schema with flag set to false returns Errors object instance and can set errors', function (assert) {
+    this.owner.register('service:m3-schema', TestSchemaFlagOff);
+
+    let model = run(() => {
+      return this.store.push({
+        data: {
+          id: 'urn:book:1',
+          type: 'com.example.bookstore.Book',
+          attributes: {
+            author: ['urn:author:1']
+          },
+        },
+      });
+    });
+
+    const oldErrors = get(model, 'errors');
+
+    assert.ok(
+      oldErrors instanceof ModelErrors,
+      "schema's useUnderlyingErrorsValue returns false should return ModelsError object instance"
+    );
+
+    set(model, 'errors', [{ message: 'hello world', cause: 'earth' }]);
+
+    assert.deepEqual(
+      oldErrors.get('firstObject'),
+      { message: 'hello world', cause: 'earth' },
+      'should return the set errors'
+    );
+  });
+
   test('schema with no flag property returns Errors object instance', function (assert) {
     this.owner.register('service:m3-schema', TestSchemaNoOverride);
 

--- a/tests/unit/model/errors-attribute-test.js
+++ b/tests/unit/model/errors-attribute-test.js
@@ -150,7 +150,7 @@ module('unit/model/errors-attribute', function (hooks) {
           id: 'urn:book:1',
           type: 'com.example.bookstore.Book',
           attributes: {
-            author: ['urn:author:1']
+            author: ['urn:author:1'],
           },
         },
       });


### PR DESCRIPTION

ensures that we have a setter for errors when using `useUnderylingErrorsValue`.

[fix #1533]