### PR TITLE
Move feature-flags from CI to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,20 +51,6 @@ jobs:
       - name: test
         run: yarn test:production
 
-  test-feature-flags:
-    name: feature flags
-    needs: [lint]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '12.x' # min node version
-      - name: yarn install
-        run: yarn --frozen-lockfile --install
-      - name: test:feature-flags
-        run: yarn run ember try:one ember-data-packages-canary --- ember test --query enableoptionalfeatures
-
   test-performance-app:
     name: performance-app
     needs: [lint]
@@ -87,7 +73,7 @@ jobs:
 
   test-node:
     name: "t:${{matrix.node}}"
-    needs: [lint, test, test-feature-flags]
+    needs: [lint, test]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -105,7 +91,7 @@ jobs:
 
   test-ember:
     name: "t:${{matrix.try-scenario}}"
-    needs: [lint, test, test-feature-flags]
+    needs: [lint, test]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,3 +42,17 @@ jobs:
         run: "yarn nyx report-failure --owner hjdivad --repo ember-m3 --run-id ${{github.run_id}}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test-feature-flags:
+    name: feature flags
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x' # min node version
+      - name: yarn install
+        run: yarn --frozen-lockfile --install
+      - name: test:feature-flags
+        run: yarn run ember try:one ember-data-packages-canary --- ember test --query enableoptionalfeatures


### PR DESCRIPTION
We depend on the Ember Data CUSTOM_MODEL_CLASS feature flag, which is
off by default in 3.24.0, and on by default in 3.28.0. We used to have
to test this feature flag against canaries prior to 3.28.0's release,
but no longer.

We no longer depend on any optional feature flags, but still run the job
to ensure that enabling optional features in Ember Data does not
otherwise break ember-m3.

The job will be red right now because we currently are not compatible
with 4.0.0 and also not with canary releases of ember and ember-data.

Co-Authored-By: Larry Yu <laryu@linkedin.com>
