### PR TITLE
Changed creating nested model condition

### DIFF
--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -292,11 +292,11 @@ function createNestedModel(store, record, recordData, key, nestedValue, parentId
 
   // Detect whether the nested model itself is replaced or new, e.g. from a user having done
   // `model.set('nestedModel', { ...newAttributes });`
-  let createDirtyNestedModel =
-    recordData.__attributes && Object.prototype.hasOwnProperty.call(recordData.__attributes, key);
+  // let createDirtyNestedModel =
+  // recordData.__attributes && Object.prototype.hasOwnProperty.call(recordData.__attributes, key);
 
   // Detect whether creating model from server payload
-  createDirtyNestedModel &&= recordData.getServerAttr && !recordData.getServerAttr(key);
+  let createDirtyNestedModel = recordData.getServerAttr && !recordData.getServerAttr(key);
 
   if (createDirtyNestedModel) {
     Object.keys(nestedValue.attributes).forEach((key) => {

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -292,11 +292,11 @@ function createNestedModel(store, record, recordData, key, nestedValue, parentId
 
   // Detect whether the nested model itself is replaced or new, e.g. from a user having done
   // `model.set('nestedModel', { ...newAttributes });`
-  // let createDirtyNestedModel =
-  //   recordData.__attributes && Object.keys(recordData.__attributes).indexOf(key) >= 0;
+  let createDirtyNestedModel =
+    recordData.__attributes && Object.prototype.hasOwnProperty.call(recordData.__attributes, key);
 
   // Detect whether creating model from server payload
-  let createDirtyNestedModel = recordData.getServerAttr && !recordData.getServerAttr(key);
+  createDirtyNestedModel &&= recordData.getServerAttr && !recordData.getServerAttr(key);
 
   if (createDirtyNestedModel) {
     Object.keys(nestedValue.attributes).forEach((key) => {

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -289,10 +289,20 @@ function createNestedModel(store, record, recordData, key, nestedValue, parentId
     internalModel.record = nestedModel;
     nestedRecordData = recordDataFor(internalModel);
   }
-  if (
-    !recordData.getServerAttr ||
-    (recordData.getServerAttr(key) !== null && recordData.getServerAttr(key) !== undefined)
-  ) {
+
+  // Detect whether the nested model itself is replaced or new, e.g. from a user having done
+  // `model.set('nestedModel', { ...newAttributes });`
+  // let createDirtyNestedModel =
+  //   recordData.__attributes && Object.keys(recordData.__attributes).indexOf(key) >= 0;
+
+  // Detect whether creating model from server payload
+  let createDirtyNestedModel = recordData.getServerAttr && !recordData.getServerAttr(key);
+
+  if (createDirtyNestedModel) {
+    Object.keys(nestedValue.attributes).forEach((key) => {
+      nestedRecordData.setAttr(key, nestedValue.attributes[key], true);
+    });
+  } else {
     nestedRecordData.pushData(
       {
         attributes: nestedValue.attributes,
@@ -301,10 +311,6 @@ function createNestedModel(store, record, recordData, key, nestedValue, parentId
       false,
       true
     );
-  } else {
-    Object.keys(nestedValue.attributes).forEach((key) => {
-      nestedRecordData.setAttr(key, nestedValue.attributes[key], true);
-    });
   }
 
   return nestedModel;

--- a/addon/resolve-attribute-util.js
+++ b/addon/resolve-attribute-util.js
@@ -289,20 +289,10 @@ function createNestedModel(store, record, recordData, key, nestedValue, parentId
     internalModel.record = nestedModel;
     nestedRecordData = recordDataFor(internalModel);
   }
-
-  // Detect whether the nested model itself is replaced or new, e.g. from a user having done
-  // `model.set('nestedModel', { ...newAttributes });`
-  let createDirtyNestedModel =
-    recordData.__attributes && Object.keys(recordData.__attributes).indexOf(key) >= 0;
-
-  // Detect whether creating model from server payload
-  createDirtyNestedModel &&= recordData.getServerAttr && !recordData.getServerAttr(key);
-
-  if (createDirtyNestedModel) {
-    Object.keys(nestedValue.attributes).forEach((key) => {
-      nestedRecordData.setAttr(key, nestedValue.attributes[key], true);
-    });
-  } else {
+  if (
+    !recordData.getServerAttr ||
+    (recordData.getServerAttr(key) !== null && recordData.getServerAttr(key) !== undefined)
+  ) {
     nestedRecordData.pushData(
       {
         attributes: nestedValue.attributes,
@@ -311,6 +301,10 @@ function createNestedModel(store, record, recordData, key, nestedValue, parentId
       false,
       true
     );
+  } else {
+    Object.keys(nestedValue.attributes).forEach((key) => {
+      nestedRecordData.setAttr(key, nestedValue.attributes[key], true);
+    });
   }
 
   return nestedModel;


### PR DESCRIPTION
When creating a nested model, currently the framework determines whether to create a nested dirty model based on whether we are creating the model from a server payload. The check is not sufficient as in the case where a user might use model.set('nestedModelAttr', {...nestedModle}). The added check makes sure that this use case is covered when creating the nested model.

Testing done:
All test cases passed in local environment.