### PR TITLE
Adding _oldWillDestroy to the prototype

### DIFF
--- a/addon/model.js
+++ b/addon/model.js
@@ -766,6 +766,7 @@ MegamorphicModel.prototype.isError = null;
 MegamorphicModel.prototype.adapterError = null;
 MegamorphicModel.prototype._identifier = null;
 MegamorphicModel.prototype._isDirty = null;
+MegamorphicModel.prototype._oldWillDestroy = null;
 
 MegamorphicModel.relationshipsByName = new Map();
 


### PR DESCRIPTION
Addressing ember-inspector error when using [nativeProperties](https://github.com/hjdivad/ember-m3/blob/master/DEPRECATIONS.md#4x).

An example of the error:
```
2i6k580nwyl2cogqdnfyozj0i:19088 Uncaught Error: Cannot set a non-whitelisted property _oldWillDestroy on type FOO
    at Proxy.setUnknownProperty (2i6k580nwyl2cogqdnfyozj0i:19088:63)
    at Object.set (2i6k580nwyl2cogqdnfyozj0i:19029:99)
    at e.retainObject (<anonymous>:4280:54)
    at RenderTree._serializeObject (<anonymous>:2172:19)
    at RenderTree._serializeItem (<anonymous>:2164:31)
    at <anonymous>:2145:28
    at Array.forEach (<anonymous>)
    at RenderTree._serializeDict (<anonymous>:2144:25)
    at RenderTree._serializeArgs (<anonymous>:2127:21)
    at RenderTree._serializeRenderNode (<anonymous>:2112:22)
```

This issue is also mentioned here: https://github.com/poteto/ember-changeset/issues/589


I tested this manually by linking ember-m3, reinstalling, and running my app and launching ember-inspector.