### PR TITLE
Cancel prior CI jobs for the same PR/branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: linting


### PR DESCRIPTION
When a new commit is pushed to a branch/PR that already has a CI job running, the older (now outdated) CI job will be canceled. This frees up CI resources and allows the new commit's CI job to get started much sooner.
