### PR TITLE
Unable to access error using index

### DIFF
--- a/tests/unit/model-test.js
+++ b/tests/unit/model-test.js
@@ -3146,6 +3146,11 @@ for (let testRun = 0; testRun < 2; testRun++) {
       const errors = get(model, 'errors');
       assert.ok(errors);
       assert.ok(errors instanceof Errors);
+
+      errors.addObjects([{}]);
+
+      assert.deepEqual(get(errors, 'firstObject'), {});
+      assert.deepEqual(get(errors, '0'), {});
     });
 
     test('.save errors getting updated via the store and removed upon setting a new value', function (assert) {


### PR DESCRIPTION
## Summary

Recently, an Ember RFC to deprecate array prototype extensions has been approved. `firstObject` is one of the array prototype extension properties which can be replaced with bracket notation `[0]`. M3 is already handling this by returning the M3TrackedArray for arrays when the API response contains arrays.

However, there is an `errors` property on the M3 model. It returns an ArrayProxy object which can't be accessed using bracket notation.