### PR TITLE
Remove node engines restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,9 +117,6 @@
     "testem": "^3.6.0",
     "webpack": "^5.75.0"
   },
-  "engines": {
-    "node": ">= 12.* <= 16.*"
-  },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },


### PR DESCRIPTION
Per the README an active version of node is still required, but in
practice node versions don't break compatibility here.  Engine
restrictions can be added back if that ever changes.
