### PR TITLE
Update to ember-source@4

### DIFF
--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -58,6 +58,23 @@ if (CUSTOM_MODEL_CLASS) {
       if (index !== null) {
         receiver.replace(index, 1, [value]);
       } else {
+        if (typeof value === 'function') {
+          // TODO: we don't really need to ignore all functions
+          // We want to ignore the functions from Ember.A(proxy) as they will
+          // clobber our own implementations
+          //
+          // We have to do this because BaseRecordArray.create -> init ->
+          // setEmerArray occurs before the proxy can be created.
+          //
+          // Later, if a user Ember.A(recordArrayProxy) Ember.A will mistakenly
+          // think it's not an ember array and apply the NativeArray mixin to
+          // the proxy.
+          //
+          // We should stop extending EmberObject.extend(MutableArray), but we
+          // still need to prevent Ember.A from clobbering our own objectAt &c.
+          return true;
+        }
+
         Reflect.set(target.__recordArray, key, value);
       }
 

--- a/addon/base-record-array.js
+++ b/addon/base-record-array.js
@@ -1,6 +1,6 @@
 import { get } from '@ember/object';
 import { dasherize } from '@ember/string';
-import EmberObject from '@ember/object';
+import EmberObject, { notifyPropertyChange } from '@ember/object';
 import MutableArray from '@ember/array/mutable';
 import { A } from '@ember/array';
 import {
@@ -112,7 +112,7 @@ if (CUSTOM_MODEL_CLASS) {
       }
 
       this._objects.splice(idx, removeAmt, ...newObjects);
-      this.arrayContentDidChange(idx, removeAmt, newObjects.length);
+      notifyPropertyChange(this, '[]');
       this._registerWithObjects(newObjects);
       this._resolved = true;
     }
@@ -191,7 +191,7 @@ if (CUSTOM_MODEL_CLASS) {
         let index = this._objects.indexOf(record);
         if (index > -1) {
           this._objects.splice(index, 1);
-          this.arrayContentDidChange(index, 1, 0);
+          notifyPropertyChange(this, '[]');
         }
       }
     }
@@ -272,7 +272,7 @@ if (CUSTOM_MODEL_CLASS) {
       this._registerWithInternalModels(newInternalModels);
       this._resolved = true;
 
-      this.arrayContentDidChange(idx, removeAmt, newRecords.length);
+      notifyPropertyChange(this, '[]');
     }
 
     objectAt(idx) {

--- a/addon/model.js
+++ b/addon/model.js
@@ -1,7 +1,13 @@
 // This lint error disables "this.attrs" everywhere.  What could go wrong?
 /* eslint-disable ember/no-attrs-in-components */
 
-import EmberObject, { computed, get, set, defineProperty } from '@ember/object';
+import EmberObject, {
+  notifyPropertyChange,
+  computed,
+  get,
+  set,
+  defineProperty,
+} from '@ember/object';
 import { isArray } from '@ember/array';
 import { assert, warn, deprecate } from '@ember/debug';
 import { readOnly } from '@ember/object/computed';
@@ -10,12 +16,7 @@ import { recordDataToRecordMap } from './utils/caches';
 import { recordDataFor } from './-private';
 import { resolveValue } from './resolve-attribute-util';
 import { computeAttributeReference, computeAttribute } from './utils/resolve';
-import {
-  assertNoChanges,
-  notifyPropertyChange,
-  deferPropertyChange,
-  flushChanges,
-} from './utils/notify-changes';
+import { assertNoChanges, deferPropertyChange, flushChanges } from './utils/notify-changes';
 import { DEBUG } from '@glimmer/env';
 import { CUSTOM_MODEL_CLASS } from 'ember-m3/-infra/features';
 import { RootState, Errors as StoreErrors } from '@ember-data/store/-private';

--- a/addon/utils/notify-changes.js
+++ b/addon/utils/notify-changes.js
@@ -1,26 +1,10 @@
 import Ember from 'ember';
-import { notifyPropertyChange as _notifyPropertyChange } from '@ember/object';
+import { notifyPropertyChange } from '@ember/object';
 import { assert } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
 const { changeProperties } = Ember;
 
-const { propertyDidChange } = Ember;
-export let notifyPropertyChange;
-
-const HasNotifyPropertyChange = _notifyPropertyChange !== undefined;
-if (HasNotifyPropertyChange) {
-  notifyPropertyChange = _notifyPropertyChange;
-} else {
-  notifyPropertyChange = propertyDidChange;
-}
-
-// Separate array & prop changes for simplicity.  This prevents us from
-// re-issuing the property changes in order, but Ember already triggers array
-// changes eagerly, even within `changeProperties`
-
-// WeakMap<Store, [obj, startIdx: number, removeCount: number, addCount: number]>
-const StoreToArrayChanges = new WeakMap();
 // WeakMap<Store, [obj, property: string]>
 const StoreToPropChanges = new WeakMap();
 
@@ -31,48 +15,19 @@ function getPropertyChanges(store) {
   return StoreToPropChanges.get(store);
 }
 
-function getArrayChanges(store) {
-  if (!StoreToArrayChanges.has(store)) {
-    StoreToArrayChanges.set(store, []);
-  }
-  return StoreToArrayChanges.get(store);
-}
-
 export function deferPropertyChange(store, obj, key) {
   getPropertyChanges(store).push(obj, key);
 }
 
-export function deferArrayPropertyChange(store, array, start, deleteCount, addCount) {
-  if (DEBUG) {
-    // don't assert Ember.isArray as that will return true for native arrays
-    assert(
-      `deferArrayPropertyChange called on something other than an Ember array; wrap native arrays with Ember.A(array) or enable Array prototype extensions`,
-      typeof array.arrayContentDidChange === 'function'
-    );
-  }
-  getArrayChanges(store).push(array, start, deleteCount, addCount);
-}
-
-function flushArrayChanges(store) {
-  let changes = StoreToArrayChanges.get(store) || [];
-  changeProperties(() => {
-    for (let i = 0; i < changes.length; i += 4) {
-      let array = changes[i];
-      let startIdx = changes[i + 1];
-      let removeCount = changes[i + 2];
-      let addCount = changes[i + 3];
-      array.arrayContentDidChange(startIdx, removeCount, addCount);
-    }
-  });
-  StoreToArrayChanges.set(store, []);
+export function deferArrayPropertyChange(store, array) {
+  deferPropertyChange(store, array, '[]');
 }
 
 function flushPropChanges(store) {
   let changes = StoreToPropChanges.get(store) || [];
   changeProperties(() => {
     for (let i = 0; i < changes.length; i += 2) {
-      let obj = changes[i];
-      let change = changes[i + 1];
+      let [obj, change] = changes;
       notifyPropertyChange(obj, change);
     }
   });
@@ -81,7 +36,6 @@ function flushPropChanges(store) {
 
 export function flushChanges(store) {
   changeProperties(() => {
-    flushArrayChanges(store);
     flushPropChanges(store);
   });
 }
@@ -89,16 +43,10 @@ export function flushChanges(store) {
 export function assertNoChanges(store) {
   if (DEBUG) {
     let propChanges = StoreToPropChanges.get(store) || [];
-    let changedProps = propChanges.filter((o, i) => i % 2 === 1);
+    let changedProps = propChanges.filter((_o, i) => i % 2 === 1);
     assert(
       `There should be no queued changes, but we have: ${changedProps.join(', ')} `,
       changedProps.length === 0
-    );
-
-    let arrayChanges = StoreToArrayChanges.get(store) || [];
-    assert(
-      `There should be no queued array changes, but we have: ${arrayChanges.length} `,
-      arrayChanges.length === 0
     );
   }
 }

--- a/addon/utils/notify-changes.js
+++ b/addon/utils/notify-changes.js
@@ -27,7 +27,8 @@ function flushPropChanges(store) {
   let changes = StoreToPropChanges.get(store) || [];
   changeProperties(() => {
     for (let i = 0; i < changes.length; i += 2) {
-      let [obj, change] = changes;
+      let obj = changes[i];
+      let change = changes[i + 1];
       notifyPropertyChange(obj, change);
     }
   });

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "ember-qunit": "^6.1.1",
     "ember-resolver": "^10.0.0",
     "ember-sinon": "^5.0.0",
-    "ember-source": "^3.28.11",
+    "ember-source": "^4.4.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-try": "^2.0.0",
     "eslint": "^7.32.0",

--- a/tests/unit/utils/notify-changes-test.js
+++ b/tests/unit/utils/notify-changes-test.js
@@ -6,7 +6,6 @@ import {
 } from 'ember-m3/utils/notify-changes';
 import { addObserver } from '@ember/object/observers';
 import { A } from '@ember/array';
-import { DEBUG } from '@glimmer/env';
 
 module('unit/utils/notify-changes', function (hooks) {
   hooks.beforeEach(function () {
@@ -46,101 +45,47 @@ module('unit/utils/notify-changes', function (hooks) {
   test('deferArrayPropertyChange + flushChanges batches array property changes', function (assert) {
     let a = A();
     let b = A();
-    a.id = 'a';
-    b.id = 'b';
     let changes = [];
 
-    let observers = {
-      willChange(/* target, idx, deleteCount, addCount */) {
-        assert.notOk(true, `array willChange is not triggered with m3's property batching`);
-      },
+    addObserver(a, '[]', function () {
+      changes.push('a');
+    });
+    addObserver(b, '[]', function () {
+      changes.push('b');
+    });
 
-      didChange(target, idx, deleteCount, addCount) {
-        changes.push([this.id, target.id, 'didChange', idx, deleteCount, addCount]);
-      },
-    };
-    a.addArrayObserver(a, observers);
-    b.addArrayObserver(b, observers);
-
-    deferArrayPropertyChange(this.store, a, 0, 1, 2);
-    deferArrayPropertyChange(this.store, a, 1, 2, 3);
-    // there's no de-duping with array changes
-    deferArrayPropertyChange(this.store, b, 0, 1, 2);
-    deferArrayPropertyChange(this.store, b, 0, 1, 2);
+    deferArrayPropertyChange(this.store, a);
+    deferArrayPropertyChange(this.store, a);
+    // these are de-duplicated
+    deferArrayPropertyChange(this.store, b);
+    deferArrayPropertyChange(this.store, b);
 
     assert.deepEqual(changes, [], 'observers have not been triggered');
     flushChanges(this.store);
-    assert.deepEqual(
-      changes,
-      [
-        ['a', 'a', 'didChange', 0, 1, 2],
-        ['a', 'a', 'didChange', 1, 2, 3],
-        ['b', 'b', 'didChange', 0, 1, 2],
-        ['b', 'b', 'didChange', 0, 1, 2],
-      ],
-      'changes triggered in order'
-    );
+    assert.deepEqual(changes, ['a', 'b'], 'changes triggered in order');
   });
 
   test('simple and array property changes can be batched together', function (assert) {
     let a = { id: 'a' };
     let b = A();
-    b.id = 'b';
     let changes = [];
 
-    let observers = {
-      willChange(/* target, idx, deleteCount, addCount */) {
-        assert.notOk(true, `array willChange is not triggered with m3's property batching`);
-      },
-
-      didChange(target, idx, deleteCount, addCount) {
-        changes.push([this.id, target.id, 'didChange', idx, deleteCount, addCount]);
-      },
-    };
-    b.addArrayObserver(b, observers);
-    addObserver(a, 'foo', () => changes.push([a, 'foo']));
-    addObserver(a, 'bar', () => changes.push([a, 'bar']));
+    addObserver(b, '[]', function () {
+      changes.push('b.[]');
+    });
+    addObserver(a, 'foo', () => changes.push('a.foo'));
+    addObserver(a, 'bar', () => changes.push('a.bar'));
 
     deferPropertyChange(this.store, a, 'foo');
-    deferArrayPropertyChange(this.store, b, 0, 1, 2);
+    deferArrayPropertyChange(this.store, b);
     deferPropertyChange(this.store, a, 'bar');
-    deferArrayPropertyChange(this.store, b, 1, 2, 3);
 
     assert.deepEqual(changes, [], 'observers have not been triggered');
     flushChanges(this.store);
     assert.deepEqual(
       changes,
-      [
-        // array changes are eager, so batching within `changeProperties` has no effect here
-        ['b', 'b', 'didChange', 0, 1, 2],
-        ['b', 'b', 'didChange', 1, 2, 3],
-        [a, 'foo'],
-        [a, 'bar'],
-      ],
+      ['b.[]', 'a.foo', 'a.bar'],
       'changes triggered in order, but array changes happen first'
     );
   });
-
-  if (DEBUG) {
-    test('deferArrayPropertyChange asserts if passed a non-Ember array', function (assert) {
-      assert.throws(
-        () => {
-          deferArrayPropertyChange(this.store, {}, 1, 2, 3);
-        },
-        /deferArrayPropertyChange called on something other than an Ember array/,
-        'assert if passed non-array'
-      );
-
-      assert.throws(
-        () => {
-          deferArrayPropertyChange(this.store, [], 1, 2, 3);
-        },
-        /deferArrayPropertyChange called on something other than an Ember array/,
-        'assert if passed native array with prototype extensions off'
-      );
-
-      // does not throw
-      deferArrayPropertyChange(this.store, A(), 1, 2, 3);
-    });
-  }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,7 +153,7 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
-"@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.16.7", "@babel/helper-module-imports@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
@@ -575,7 +575,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-block-scoping@^7.20.2", "@babel/plugin-transform-block-scoping@^7.8.3":
+"@babel/plugin-transform-block-scoping@^7.16.0", "@babel/plugin-transform-block-scoping@^7.20.2", "@babel/plugin-transform-block-scoping@^7.8.3":
   version "7.20.11"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz#9f5a3424bd112a3f32fe0cf9364fbb155cff262a"
   integrity sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==
@@ -712,13 +712,6 @@
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.18.6.tgz#d128f376ae200477f37c4ddfcc722a8a1b3246a8"
   integrity sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.18.6"
-
-"@babel/plugin-transform-object-assign@^7.8.3":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.18.6.tgz#7830b4b6f83e1374a5afb9f6111bcfaea872cdd2"
-  integrity sha512-mQisZ3JfqWh2gVXvfqYCAAyRs6+7oev+myBsTwW5RnPhYXOTuCEw2oe3YgxlXMViXUS53lG8koulI7mJ+8JE+A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
@@ -1467,10 +1460,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
-"@glimmer/vm-babel-plugins@0.80.3":
-  version "0.80.3"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.80.3.tgz#434b62172318cac43830d3ac29818cf2c5f111c1"
-  integrity sha512-9ej6xlm5MzHBJ5am2l0dbbn8Z0wJoYoMpM8FcrGMlUP6SPMLWxvxpMsApgQo8u6dvZRCjR3/bw3fdf7GOy0AFw==
+"@glimmer/vm-babel-plugins@0.84.2":
+  version "0.84.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.84.2.tgz#653ce82a6656b4396d87a479d8699450d35a17f0"
+  integrity sha512-HS2dEbJ3CgXn56wk/5QdudM7rE3vtNMvPIoG7Rrg+GhkGMNxBCIRxOeEF2g520j9rwlA2LAZFpc7MCDMFbTjNA==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
@@ -3095,7 +3088,7 @@ broccoli-clean-css@^1.1.0:
     inline-source-map-comment "^1.0.5"
     json-stable-stringify "^1.0.0"
 
-broccoli-concat@^4.2.4, broccoli-concat@^4.2.5:
+broccoli-concat@^4.2.5:
   version "4.2.5"
   resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-4.2.5.tgz#d578f00094048b5fc87195e82fbdbde20d838d29"
   integrity sha512-dFB5ATPwOyV8S2I7a07HxCoutoq23oY//LhM6Mou86cWUTB174rND5aQLR7Fu8FjFFLxoTbkk7y0VPITJ1IQrw==
@@ -4542,7 +4535,7 @@ electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
-ember-auto-import@^2.2.4, ember-auto-import@^2.4.3, ember-auto-import@^2.6.0:
+ember-auto-import@^2.2.4, ember-auto-import@^2.4.1, ember-auto-import@^2.4.3, ember-auto-import@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-2.6.0.tgz#c7a2f799c9b700d74648cb02e35cf7bc1b44ac02"
   integrity sha512-xUyypxlaqWvrx2KSseLus0H8K7Dt+sXNCvcxtquT2EmIM6r67NuQUT9woiEMa9UBvqcaX2k9hNLeubDl78saig==
@@ -4603,7 +4596,7 @@ ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   resolved "https://registry.yarnpkg.com/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.1.tgz#5016b80cdef37036c4282eef2d863e1d73576879"
   integrity sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.1, ember-cli-babel@^7.26.11, ember-cli-babel@^7.26.5, ember-cli-babel@^7.26.6, ember-cli-babel@^7.7.3:
   version "7.26.11"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.11.tgz#50da0fe4dcd99aada499843940fec75076249a9f"
   integrity sha512-JJYeYjiz/JTn34q7F5DSOjkkZqy8qwFOOxXfE6pe9yEJqWGu4qErKxlz8I22JoVEQ/aBUO+OcKTpmctvykM9YA==
@@ -4740,6 +4733,14 @@ ember-cli-test-loader@^3.0.0:
   integrity sha512-wfFRBrfO9gaKScYcdQxTfklx9yp1lWK6zv1rZRpkas9z2SHyJojF7NOQRWQgSB3ypm7vfpiF8VsFFVVr7VBzAQ==
   dependencies:
     ember-cli-babel "^7.13.2"
+
+ember-cli-typescript-blueprint-polyfill@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-typescript-blueprint-polyfill/-/ember-cli-typescript-blueprint-polyfill-0.1.0.tgz#5917646a996b452a3a6b3f306ab2a27e93ea2cc2"
+  integrity sha512-g0weUTOnHmPGqVZzkQTl3Nbk9fzEdFkEXydCs5mT1qBjXh8eQ6VlmjjGD5/998UXKuA0pLSCVVMbSp/linLzGA==
+  dependencies:
+    chalk "^4.0.0"
+    remove-types "^1.0.0"
 
 ember-cli-typescript@3.0.0:
   version "3.0.0"
@@ -5056,36 +5057,36 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@^3.28.11:
-  version "3.28.11"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.28.11.tgz#7b1a7d0483c886af8f38cc058fd647c359803543"
-  integrity sha512-oM3X2lYUWJM+CJEdPvJGVZNUTzUAYbDeOOoAJW7im20LkQrv0ce0MAJ1Gf/SnI3H+ZL7lj8qggP+D9P7ZxBvsw==
+ember-source@^4.4.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-4.10.0.tgz#5f52bf8adacaddcbb3496d3e0df7ab3b7a31c1be"
+  integrity sha512-Y7+M+vSygMrpq4szsnpik3PxdVVA7ApuwU2L/l9Os+qpPqIKy4hT0Rw/17z4b87HNEX03jv7ueMbgcpxjUf1Kw==
   dependencies:
-    "@babel/helper-module-imports" "^7.8.3"
-    "@babel/plugin-transform-block-scoping" "^7.8.3"
-    "@babel/plugin-transform-object-assign" "^7.8.3"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/plugin-transform-block-scoping" "^7.16.0"
     "@ember/edition-utils" "^1.2.0"
-    "@glimmer/vm-babel-plugins" "0.80.3"
+    "@glimmer/vm-babel-plugins" "0.84.2"
     babel-plugin-debug-macros "^0.3.4"
     babel-plugin-filter-imports "^4.0.0"
-    broccoli-concat "^4.2.4"
+    broccoli-concat "^4.2.5"
     broccoli-debug "^0.6.4"
     broccoli-file-creator "^2.1.1"
-    broccoli-funnel "^2.0.2"
+    broccoli-funnel "^3.0.8"
     broccoli-merge-trees "^4.2.0"
     chalk "^4.0.0"
-    ember-cli-babel "^7.23.0"
+    ember-auto-import "^2.4.1"
+    ember-cli-babel "^7.26.11"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-path-utils "^1.0.0"
     ember-cli-string-utils "^1.1.0"
-    ember-cli-version-checker "^5.1.1"
+    ember-cli-typescript-blueprint-polyfill "^0.1.0"
+    ember-cli-version-checker "^5.1.2"
     ember-router-generator "^2.0.0"
-    inflection "^1.12.0"
-    jquery "^3.5.1"
-    resolve "^1.17.0"
-    semver "^7.3.4"
+    inflection "^1.13.2"
+    resolve "^1.22.0"
+    semver "^7.3.7"
     silent-error "^1.1.1"
 
 ember-try-config@^4.0.0:
@@ -6849,7 +6850,7 @@ infer-owner@^1.0.4:
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
 
-inflection@^1.12.0, inflection@^1.13.4, inflection@~1.13.1:
+inflection@^1.13.2, inflection@^1.13.4, inflection@~1.13.1:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/inflection/-/inflection-1.13.4.tgz#65aa696c4e2da6225b148d7a154c449366633a32"
   integrity sha512-6I/HUDeYFfuNCVS3td055BaXBwKYuzw7K3ExVMStBowKo9oOAMJIXIHvdyR3iboTCp1b+1i5DSkIZTcwIktuDw==
@@ -7460,11 +7461,6 @@ jest-worker@^27.4.5:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
-
-jquery@^3.5.1:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.3.tgz#23ed2ffed8a19e048814f13391a19afcdba160e6"
-  integrity sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg==
 
 js-string-escape@^1.0.1:
   version "1.0.1"
@@ -10131,7 +10127,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.1, resolve@^1.4.0, resolve@^1.5.0:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.20.0, resolve@^1.22.0, resolve@^1.22.1, resolve@^1.4.0, resolve@^1.5.0:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -10432,7 +10428,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.1.1, semver@^6.1.2, semver@^6.2.0, semve
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.0.0, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.8:
+semver@^7.0.0, semver@^7.1.3, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==


### PR DESCRIPTION
- Upgrade ember-source to 3.28.11
- Fix LinkTo deprecation
- Fix template deprecations
- Remove bowerrc
- Bump some deps
- jsconfig for LSP configuration
- v6 changelog
- Fix deprecations
- Upgrade to ember-source@4
- Notify array changes via `[]`
- Use notifyPropertyChange from @ember/object
- fixup notify array changes
- Replace arrayContentDidChange
- Test cleanup for readability
- Fix Ember.A clobbering
