### PR TITLE
Fix cache merging

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -951,6 +951,10 @@ export default class M3RecordData {
       // use the base model name if it is available, but otherwise just use the model name - it might be already
       // the base one
       let childBaseModelName = this._schema.computeBaseModelName(modelName) || modelName;
+      if (childBaseModelName) {
+        // this is userland API so we have to normalize the name via dasherization
+        childBaseModelName = dasherize(childBaseModelName);
+      }
       baseChildRecordData = this._baseRecordData._getChildRecordData(
         key,
         idx,

--- a/tests/dummy/app/serializers/application.js
+++ b/tests/dummy/app/serializers/application.js
@@ -10,6 +10,18 @@ export default class ApplicationSerializer {
     return store.push(payload);
   }
 
+  serialize(snapshot) {
+    let result = {};
+    snapshot.eachAttribute((k) => {
+      let value = snapshot.record.get(k);
+      if (value && typeof value.serialize === 'function') {
+        value = value.serialize();
+      }
+      result[k] = value;
+    });
+    return result;
+  }
+
   static create(createArgs) {
     return new this(createArgs);
   }

--- a/tests/unit/model/nested-merged-test.js
+++ b/tests/unit/model/nested-merged-test.js
@@ -1,0 +1,110 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import DefaultSchema from 'ember-m3/services/m3-schema';
+
+module(`unit/model/nested-merged`, function (hooks) {
+  setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('merging nested is dasherize-indifferent', function (assert) {
+    class TestSchema extends DefaultSchema {
+      includesModel() {
+        return true;
+      }
+
+      computeBaseModelName(modelName) {
+        if (/^base:/i.test(modelName)) {
+          return undefined;
+        }
+
+        // Simulate a user returning un-dasherized model names in their
+        // `computeBaseModelName` hook`
+        if (/book-characters/i.test(modelName)) {
+          return `base:BookCharacters`;
+        }
+
+        return `base:${modelName}`;
+      }
+
+      computeAttribute(key, value, modelName, schemaInterface) {
+        if (typeof value === 'object' && value !== null) {
+          let type = key;
+
+          if (/^base:/i.test(modelName)) {
+            type = `base:${type}`;
+          }
+
+          return schemaInterface.nested({
+            id: 'nested',
+            type,
+            attributes: value,
+          });
+        }
+      }
+    }
+    this.owner.register('service:m3-schema', TestSchema);
+
+    this.store.pushPayload('com.example.bookstore.Book', {
+      data: {
+        id: 'book:1',
+        type: 'base:com.example.bookstore.Book',
+        attributes: {
+          title: 'Marlborough: his life and times',
+          volume: 1,
+          BookCharacters: {
+            marlborough: 'John Churchilll',
+          },
+        },
+      },
+      included: [
+        {
+          id: 'book:1',
+          type: 'com.example.bookstore.Book',
+        },
+      ],
+    });
+
+    let book = this.store.peekRecord('com.example.bookstore.Book', 'book:1');
+
+    assert.deepEqual(
+      book.toJSON(),
+      {
+        BookCharacters: {
+          marlborough: 'John Churchilll',
+        },
+        title: 'Marlborough: his life and times',
+        volume: 1,
+      },
+      'book - first push'
+    );
+
+    this.store.pushPayload('com.example.bookstore.Book', {
+      data: {
+        id: 'book:1',
+        type: 'base:com.example.bookstore.Book',
+        attributes: {
+          title: 'Marlborough: his life and times',
+          volume: 1,
+          BookCharacters: {
+            vendome: 'Loius Joseph',
+          },
+        },
+      },
+    });
+    assert.deepEqual(
+      book.toJSON(),
+      {
+        BookCharacters: {
+          marlborough: 'John Churchilll',
+          vendome: 'Loius Joseph',
+        },
+        title: 'Marlborough: his life and times',
+        volume: 1,
+      },
+      'book - second push'
+    );
+  });
+});


### PR DESCRIPTION
Nested models would not previously be merged under the following
conditions:
  1. the nested models were projections of base models
  2. the userland `computeBaseModelName` hook returned an undasherized
     model name for nested models

This was due to a missing call to dasherize, to keep names normalized
for Ember Data.
