### PR TITLE
feat: side-channel for nested record datas

### DIFF
--- a/addon/record-data.js
+++ b/addon/record-data.js
@@ -964,7 +964,7 @@ export default class M3RecordData {
       );
     }
 
-    return new M3RecordData(
+    return this.storeWrapper.createNestedRecordData(
       modelName,
       id,
       null,

--- a/addon/services/store.js
+++ b/addon/services/store.js
@@ -90,6 +90,10 @@ export default class M3Store extends Store {
 
   createRecordDataFor(modelName, id, clientId, storeWrapper) {
     let schemaManager = get(this, '_schemaManager');
+    storeWrapper.createNestedRecordData = function (...args) {
+      return new M3RecordData(...args);
+    };
+
     if (schemaManager.includesModel(modelName)) {
       seenTypesPerStore.get(this).add(modelName);
 

--- a/tests/unit/record-data-test.js
+++ b/tests/unit/record-data-test.js
@@ -84,6 +84,11 @@ for (let testRun = 0; testRun < 2; testRun++) {
             return this.recordDataFor(...arguments);
           },
 
+          // see addon/store.js#createRecordDataFor
+          createNestedRecordData(...args) {
+            return new M3RecordData(...args);
+          },
+
           recordDataFor(modelName, id, clientId) {
             let key = recordDataKey({ modelName, id });
             return (


### PR DESCRIPTION
Update embedded model creation to go via the store wrapper.

This allows downstreams to override `createNestedRecordData` in case they have any custom record data code.