### PR TITLE
chore: Updated CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: yarn test
 
   test-node:
-    name: "node:${{matrix.node}}"
+    name: 'node:${{matrix.node}}'
     needs: [lint, test]
     runs-on: ubuntu-latest
     strategy:
@@ -94,13 +94,13 @@ jobs:
         run: yarn test
 
   test-ember:
-    name: "t:${{matrix.try-scenario}}"
+    name: 't:${{matrix.try-scenario}}'
     needs: [lint, test]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        try-scenario: [ember-latest, ember-lts, ember-lts-1, ember-data-lts-3-x]
+        try-scenario: [ember-lts, ember-lts-1, ember-data-lts-3-x]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -110,20 +110,3 @@ jobs:
         run: yarn --frozen-lockfile --install
       - name: try ${{matrix.try-scenario}}
         run: yarn run ember try:one ${{matrix.try-scenario}}
-
-  browser-tests:
-    needs: [lint]
-    runs-on: windows-latest
-    name: test-ie
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '16.x' # preferred node version
-      - name: yarn install
-        run: yarn --frozen-lockfile --install
-      - name: test
-        env:
-          TESTEM_CI_LAUNCHER: IE
-          CI: true
-        run: yarn run ember try:one ember-data-lts-3-x

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        try-scenario: [ember-beta, ember-alpha, ember-data-beta, ember-data-canary]
+        try-scenario: [ember-latest, ember-beta, ember-alpha, ember-data-beta, ember-data-canary]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,7 +7,7 @@ const getDebugMacros = require('./src/debug-macros').debugMacros;
 
 function hasDataPackage() {
   try {
-    // eslint-disable-next-line node/no-missing-require
+    // eslint-disable-next-line node/no-missing-require, node/no-extraneous-require
     require.resolve('ember-data');
     return true;
   } catch (e) {


### PR DESCRIPTION
1. Moved ember-latest to nightly
ember-latest tests against ember-source 5.x, which is NOT supported by ember-m3 yet
3. Removed test-ie
IE is no longer supported by the industry