### PR TITLE
Remove Implicit Injections in m3-store

### DIFF
--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -18,10 +18,6 @@ function initializeDebugAdapter(registry) {
 }
 
 export function initialize(application) {
-  // This should be unnecessary
-  // it is done by the meta package
-  // but it should be done by the store package
-  // https://github.com/emberjs/data/issues/7158
   initializeDebugAdapter(application);
 }
 

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -1,5 +1,6 @@
 import { DEBUG } from '@glimmer/env';
 import require from 'require';
+import { gte } from 'ember-compatibility-helpers';
 
 /*
  Configures a registry with injections on Ember applications
@@ -18,6 +19,16 @@ function initializeDebugAdapter(registry) {
 }
 
 export function initialize(application) {
+  // Implicit injections are deprecated in Ember 4.0
+  // https://deprecations.emberjs.com/v3.x/#toc_implicit-injections
+  if (!gte('4.0.0')) {
+    // This should be unnecessary
+    // it is done by the meta package
+    // but it should be done by the store package
+    // https://github.com/emberjs/data/issues/7158
+    application.inject('route', 'store', 'service:store');
+    application.inject('controller', 'store', 'service:store');
+  }
   initializeDebugAdapter(application);
 }
 

--- a/addon/initializers/m3-store.js
+++ b/addon/initializers/m3-store.js
@@ -22,8 +22,6 @@ export function initialize(application) {
   // it is done by the meta package
   // but it should be done by the store package
   // https://github.com/emberjs/data/issues/7158
-  application.inject('route', 'store', 'service:store');
-  application.inject('controller', 'store', 'service:store');
   initializeDebugAdapter(application);
 }
 

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "broccoli-funnel": "^3.0.8",
     "ember-cli-babel": "^7.26.11",
     "ember-cli-version-checker": "^5.1.2",
+    "ember-compatibility-helpers": "^1.2.6",
     "semver": "^7.3.5"
   },
   "devDependencies": {
@@ -87,7 +88,6 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-uglify": "^3.0.0",
-    "ember-compatibility-helpers": "^1.2.6",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-fetch": "^8.1.2",
     "ember-inflector": "^4.0.2",


### PR DESCRIPTION
This silences the deprecation in apps running Ember 4.

https://deprecations.emberjs.com/v4.x/#toc_implicit-injections

For apps running Ember 4, this does nothing so is safe to remove